### PR TITLE
[CF-446] Create new feeds for Cloud Feeds user access events

### DIFF
--- a/allfeeds.wadl
+++ b/allfeeds.wadl
@@ -73,6 +73,12 @@
         <resource id="encore_events"
                   path="encore/events" 
                   type="wadl/feed.wadl#AtomFeed wadl/feed.wadl#Validated"/>
+        <resource id="feedsaccess_events"
+                  path="feeds_access/events"
+                  type="wadl/feed.wadl#AtomFeed
+                        wadl/feed.wadl#TenantAtomFeed
+                        wadl/cadf.wadl#UserAccessEvent
+                        wadl/cadf.wadl#UserAccessEventTenant" />
         <resource id="files_events"
                   path="files/events" 
                   type="wadl/feed.wadl#AtomFeed wadl/product.wadl#CloudFiles wadl/feed.wadl#TenantAtomFeed  wadl/product.wadl#CloudFilesTenant"/>
@@ -148,7 +154,7 @@
         <resource id="usagesummaryrecovery_events"
                   path="usagesummaryrecovery/events" 
                   type="wadl/feed.wadl#AtomFeed wadl/feed.wadl#Unvalidated"/>
-        
+
         <!-- Feeds Catalog -->
         <resource id="feedscatalog"
                   path="feedscatalog/catalog" 
@@ -211,6 +217,7 @@
                         wadl/product.wadl#SslTenant
                         wadl/product.wadl#Support
                         wadl/feed.wadl#UsageDeadLetter
+                        wadl/cadf.wadl#UserAccessEvent
                         wadl/product.wadl#Widget wadl/product.wadl#WidgetSummary"/>
             <resource id="functest2_events"
                   path="functest2/events" 

--- a/bad_message_samples/corexsd/identity-user-acess-event-contenttype-mismatch-with-content.xml
+++ b/bad_message_samples/corexsd/identity-user-acess-event-contenttype-mismatch-with-content.xml
@@ -25,7 +25,7 @@
             <cadf:attachments>
                 <cadf:attachment name="auditData" contentType="ua:wrongContentType">
                     <cadf:content>
-                        <ua:auditData>
+                        <ua:auditData version="1">
                             <ua:region>DFW</ua:region>
                             <ua:dataCenter>DFW1</ua:dataCenter>
                             <ua:methodLabel>createToken</ua:methodLabel>

--- a/bad_message_samples/corexsd/identity-user-acess-event-missing-initiator.xml
+++ b/bad_message_samples/corexsd/identity-user-acess-event-missing-initiator.xml
@@ -21,7 +21,7 @@
             <cadf:attachments>
                 <cadf:attachment name="auditData" contentType="ua:auditData">
                     <cadf:content>
-                        <ua:auditData>
+                        <ua:auditData version="1">
                             <ua:region>DFW</ua:region>
                             <ua:dataCenter>DFW1</ua:dataCenter>
                             <ua:methodLabel>createToken</ua:methodLabel>

--- a/bad_message_samples/corexsd/identity-user-acess-event-missing-outcome.xml
+++ b/bad_message_samples/corexsd/identity-user-acess-event-missing-outcome.xml
@@ -24,7 +24,7 @@
             <cadf:attachments>
                 <cadf:attachment name="auditData" contentType="ua:auditData">
                     <cadf:content>
-                        <ua:auditData>
+                        <ua:auditData version="1">
                             <ua:region>DFW</ua:region>
                             <ua:dataCenter>DFW1</ua:dataCenter>
                             <ua:methodLabel>createToken</ua:methodLabel>

--- a/bad_message_samples/corexsd/identity-user-acess-event-missing-requestURL-in-auditdata.xml
+++ b/bad_message_samples/corexsd/identity-user-acess-event-missing-requestURL-in-auditdata.xml
@@ -25,7 +25,7 @@
             <cadf:attachments>
                 <cadf:attachment name="auditData" contentType="ua:auditData">
                     <cadf:content>
-                        <ua:auditData>
+                        <ua:auditData version="1">
                             <ua:region>DFW</ua:region>
                             <ua:dataCenter>DFW1</ua:dataCenter>
                             <ua:methodLabel>createToken</ua:methodLabel>

--- a/bad_message_samples/feedsaccess/feeds-user-acess-event-contenttype-mismatch-with-content.xml
+++ b/bad_message_samples/feedsaccess/feeds-user-acess-event-contenttype-mismatch-with-content.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?atom feed="functest1/events"?>
+<?atom feed="feeds_access/events"?>
+<?expect code="400" message="The content property value not same as the value identified by contentType."?>
 <atom:entry xmlns:atom="http://www.w3.org/2005/Atom"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns="http://www.w3.org/2001/XMLSchema">
@@ -18,17 +19,17 @@
             <cadf:initiator id="10.1.2.3" typeURI="network/node" name="jackhandy">
                 <cadf:host address="10.1.2.3" agent="curl/7.8 (i386-redhat-linux-gnu) libcurl 7.8" />
             </cadf:initiator>
-            <cadf:target id="x.x.x.x" typeURI="service" name="IDM" >
-                <cadf:host address="lon.identity.api.rackspacecloud.com" />
+            <cadf:target id="x.x.x.x" typeURI="service" name="feeds" >
+                <cadf:host address="atom.prod.dfw1.us.ci.rackspace.net" />
             </cadf:target>
             <cadf:attachments>
-                <cadf:attachment name="auditData" contentType="ua:auditData">
+                <cadf:attachment name="auditData" contentType="ua:wrongContentType">
                     <cadf:content>
                         <ua:auditData version="1">
                             <ua:region>DFW</ua:region>
                             <ua:dataCenter>DFW1</ua:dataCenter>
                             <ua:methodLabel>createToken</ua:methodLabel>
-                            <ua:requestURL>https://lon.identity.api.rackspacecloud.com/v2.0/tokens</ua:requestURL>
+                            <ua:requestURL>https://ord.feeds.api.rackspacecloud.com/sites/events</ua:requestURL>
                             <ua:queryString></ua:queryString>
                             <ua:tenantId>123456</ua:tenantId>
                             <ua:responseMessage>OK</ua:responseMessage>

--- a/bad_message_samples/feedsaccess/feeds-user-acess-event-missing-initiator.xml
+++ b/bad_message_samples/feedsaccess/feeds-user-acess-event-missing-initiator.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?atom feed="functest1/events"?>
+<?atom feed="feeds_access/events"?>
+<?expect code="400" message="initiator"?>
 <atom:entry xmlns:atom="http://www.w3.org/2005/Atom"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns="http://www.w3.org/2001/XMLSchema">
@@ -14,12 +15,8 @@
                     eventTime="2015-03-12T13:20:00-05:00"
                     action="create/post"
                     outcome="success">
-            <!--racker -->
-            <cadf:initiator id="10.1.2.3" typeURI="network/node" name="jackhandy">
-                <cadf:host address="10.1.2.3" agent="curl/7.8 (i386-redhat-linux-gnu) libcurl 7.8" />
-            </cadf:initiator>
-            <cadf:target id="x.x.x.x" typeURI="service" name="IDM" >
-                <cadf:host address="lon.identity.api.rackspacecloud.com" />
+            <cadf:target id="x.x.x.x" typeURI="service" name="feeds" >
+                <cadf:host address="atom.prod.dfw1.us.ci.rackspace.net" />
             </cadf:target>
             <cadf:attachments>
                 <cadf:attachment name="auditData" contentType="ua:auditData">
@@ -28,7 +25,7 @@
                             <ua:region>DFW</ua:region>
                             <ua:dataCenter>DFW1</ua:dataCenter>
                             <ua:methodLabel>createToken</ua:methodLabel>
-                            <ua:requestURL>https://lon.identity.api.rackspacecloud.com/v2.0/tokens</ua:requestURL>
+                            <ua:requestURL>https://ord.feeds.api.rackspacecloud.com/sites/events</ua:requestURL>
                             <ua:queryString></ua:queryString>
                             <ua:tenantId>123456</ua:tenantId>
                             <ua:responseMessage>OK</ua:responseMessage>

--- a/bad_message_samples/feedsaccess/feeds-user-acess-event-missing-outcome.xml
+++ b/bad_message_samples/feedsaccess/feeds-user-acess-event-missing-outcome.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?atom feed="functest1/events"?>
+<?atom feed="feeds_access/events"?>
+<?expect code="400" message="outcome"?>
 <atom:entry xmlns:atom="http://www.w3.org/2005/Atom"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns="http://www.w3.org/2001/XMLSchema">
@@ -12,14 +13,13 @@
                     eventType="activity"
                     typeURI="http://schemas.dmtf.org/cloud/audit/1.0/event"
                     eventTime="2015-03-12T13:20:00-05:00"
-                    action="create/post"
-                    outcome="success">
+                    action="create/post">
             <!--racker -->
             <cadf:initiator id="10.1.2.3" typeURI="network/node" name="jackhandy">
                 <cadf:host address="10.1.2.3" agent="curl/7.8 (i386-redhat-linux-gnu) libcurl 7.8" />
             </cadf:initiator>
-            <cadf:target id="x.x.x.x" typeURI="service" name="IDM" >
-                <cadf:host address="lon.identity.api.rackspacecloud.com" />
+            <cadf:target id="x.x.x.x" typeURI="service" name="feeds" >
+                <cadf:host address="atom.prod.dfw1.us.ci.rackspace.net" />
             </cadf:target>
             <cadf:attachments>
                 <cadf:attachment name="auditData" contentType="ua:auditData">
@@ -28,7 +28,7 @@
                             <ua:region>DFW</ua:region>
                             <ua:dataCenter>DFW1</ua:dataCenter>
                             <ua:methodLabel>createToken</ua:methodLabel>
-                            <ua:requestURL>https://lon.identity.api.rackspacecloud.com/v2.0/tokens</ua:requestURL>
+                            <ua:requestURL>https://ord.feeds.api.rackspacecloud.com/sites/events</ua:requestURL>
                             <ua:queryString></ua:queryString>
                             <ua:tenantId>123456</ua:tenantId>
                             <ua:responseMessage>OK</ua:responseMessage>

--- a/bad_message_samples/feedsaccess/feeds-user-acess-event-missing-requestURL-in-auditdata.xml
+++ b/bad_message_samples/feedsaccess/feeds-user-acess-event-missing-requestURL-in-auditdata.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?atom feed="functest1/events"?>
+<?atom feed="feeds_access/events"?>
+<?expect code="400" message="requestURL"?>
 <atom:entry xmlns:atom="http://www.w3.org/2005/Atom"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns="http://www.w3.org/2001/XMLSchema">
@@ -18,8 +19,8 @@
             <cadf:initiator id="10.1.2.3" typeURI="network/node" name="jackhandy">
                 <cadf:host address="10.1.2.3" agent="curl/7.8 (i386-redhat-linux-gnu) libcurl 7.8" />
             </cadf:initiator>
-            <cadf:target id="x.x.x.x" typeURI="service" name="IDM" >
-                <cadf:host address="lon.identity.api.rackspacecloud.com" />
+            <cadf:target id="x.x.x.x" typeURI="service" name="feeds" >
+                <cadf:host address="atom.prod.dfw1.us.ci.rackspace.net" />
             </cadf:target>
             <cadf:attachments>
                 <cadf:attachment name="auditData" contentType="ua:auditData">
@@ -28,7 +29,6 @@
                             <ua:region>DFW</ua:region>
                             <ua:dataCenter>DFW1</ua:dataCenter>
                             <ua:methodLabel>createToken</ua:methodLabel>
-                            <ua:requestURL>https://lon.identity.api.rackspacecloud.com/v2.0/tokens</ua:requestURL>
                             <ua:queryString></ua:queryString>
                             <ua:tenantId>123456</ua:tenantId>
                             <ua:responseMessage>OK</ua:responseMessage>

--- a/bad_message_samples/feedsaccess/feeds-user-acess-event-v1-entry-invalid-content-non-cadf.xml
+++ b/bad_message_samples/feedsaccess/feeds-user-acess-event-v1-entry-invalid-content-non-cadf.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?atom feed="feeds_access/events"?>
+<?expect code="400" message="Bad Content: This feed only allows CADF events. The version and namespace of the CADF attachment content should correspond to user access events."?>
+<atom:entry xmlns="http://docs.rackspace.com/core/event"
+            xmlns:cb-bin="http://docs.rackspace.com/usage/cloudbackup/bandwidthIn"
+            xmlns:atom="http://www.w3.org/2005/Atom">
+    <atom:content type="application/xml">
+        <event endTime="2012-06-15T10:19:52Z" startTime="2012-06-14T10:19:52Z"
+               region="DFW" dataCenter="DFW1" type="USAGE"
+               id="8d89673c-c989-11e1-895a-0b3d632a8a89"
+               resourceId="3863d42a-ec9a-11e1-8e12-df8baa3ca440"
+               tenantId="1234" version="1">
+            <cb-bin:product version="1" serviceCode="CloudBackup"
+                            serverID="944576fa-ec99-11e1-bb8e-ebb21b47fa86"
+                            bandwidthIn="192998" resourceType="AGENT"/>
+        </event>
+    </atom:content>
+</atom:entry>

--- a/bad_message_samples/feedsaccess/feeds-user-acess-event-v1-entry-invalid-version.xml
+++ b/bad_message_samples/feedsaccess/feeds-user-acess-event-v1-entry-invalid-version.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?atom feed="functest1/events"?>
+<?atom feed="feeds_access/events"?>
+<?expect code="400" message="Bad Content: This feed only allows CADF events. The version and namespace of the CADF attachment content should correspond to user access events."?>
 <atom:entry xmlns:atom="http://www.w3.org/2005/Atom"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns="http://www.w3.org/2001/XMLSchema">
@@ -12,28 +13,28 @@
                     eventType="activity"
                     typeURI="http://schemas.dmtf.org/cloud/audit/1.0/event"
                     eventTime="2015-03-12T13:20:00-05:00"
-                    action="create/post"
+                    action="read/get"
                     outcome="success">
             <!--racker -->
             <cadf:initiator id="10.1.2.3" typeURI="network/node" name="jackhandy">
                 <cadf:host address="10.1.2.3" agent="curl/7.8 (i386-redhat-linux-gnu) libcurl 7.8" />
             </cadf:initiator>
-            <cadf:target id="x.x.x.x" typeURI="service" name="IDM" >
-                <cadf:host address="lon.identity.api.rackspacecloud.com" />
+            <cadf:target id="x.x.x.x" typeURI="service" name="feeds" >
+                <cadf:host address="atom.prod.dfw1.us.ci.rackspace.net" />
             </cadf:target>
             <cadf:attachments>
                 <cadf:attachment name="auditData" contentType="ua:auditData">
                     <cadf:content>
-                        <ua:auditData version="1">
+                        <ua:auditData version="2">
                             <ua:region>DFW</ua:region>
                             <ua:dataCenter>DFW1</ua:dataCenter>
-                            <ua:methodLabel>createToken</ua:methodLabel>
-                            <ua:requestURL>https://lon.identity.api.rackspacecloud.com/v2.0/tokens</ua:requestURL>
-                            <ua:queryString></ua:queryString>
+                            <ua:methodLabel>usage</ua:methodLabel>
+                            <ua:requestURL>https://ord.feeds.api.rackspacecloud.com/sites/events</ua:requestURL>
+                            <ua:queryString>limit=10</ua:queryString>
                             <ua:tenantId>123456</ua:tenantId>
                             <ua:responseMessage>OK</ua:responseMessage>
                             <ua:userName>jackhandy</ua:userName>
-                            <ua:roles>xxx</ua:roles>
+                            <ua:roles>cloudfeeds-observer</ua:roles>
                         </ua:auditData>
                     </cadf:content>
                 </cadf:attachment>

--- a/bad_message_samples/feedsaccess/feeds-user-acess-event-v1-entry-unknown-content-type.xml
+++ b/bad_message_samples/feedsaccess/feeds-user-acess-event-v1-entry-unknown-content-type.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?atom feed="functest1/events"?>
+<?atom feed="feeds_access/events"?>
+<?expect code="400" message="Bad Content: This feed only allows CADF events. The version and namespace of the CADF attachment content should correspond to user access events."?>
 <atom:entry xmlns:atom="http://www.w3.org/2005/Atom"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns="http://www.w3.org/2001/XMLSchema">
+            xmlns="http://www.w3.org/2001/XMLSchema"
+            xmlns:xx="http://www.w3.org/2001/XMLSchema">
     <atom:title>UserAccessEvent</atom:title>
     <atom:content type="application/xml">
         <cadf:event xmlns:cadf="http://schemas.dmtf.org/cloud/audit/1.0/event"
@@ -12,29 +14,29 @@
                     eventType="activity"
                     typeURI="http://schemas.dmtf.org/cloud/audit/1.0/event"
                     eventTime="2015-03-12T13:20:00-05:00"
-                    action="create/post"
+                    action="read/get"
                     outcome="success">
             <!--racker -->
             <cadf:initiator id="10.1.2.3" typeURI="network/node" name="jackhandy">
                 <cadf:host address="10.1.2.3" agent="curl/7.8 (i386-redhat-linux-gnu) libcurl 7.8" />
             </cadf:initiator>
-            <cadf:target id="x.x.x.x" typeURI="service" name="IDM" >
-                <cadf:host address="lon.identity.api.rackspacecloud.com" />
+            <cadf:target id="x.x.x.x" typeURI="service" name="feeds" >
+                <cadf:host address="atom.prod.dfw1.us.ci.rackspace.net" />
             </cadf:target>
             <cadf:attachments>
-                <cadf:attachment name="auditData" contentType="ua:auditData">
+                <cadf:attachment name="auditData" contentType="xx:unknownData">
                     <cadf:content>
-                        <ua:auditData version="1">
+                        <xx:unknownData version="1">
                             <ua:region>DFW</ua:region>
                             <ua:dataCenter>DFW1</ua:dataCenter>
-                            <ua:methodLabel>createToken</ua:methodLabel>
-                            <ua:requestURL>https://lon.identity.api.rackspacecloud.com/v2.0/tokens</ua:requestURL>
-                            <ua:queryString></ua:queryString>
+                            <ua:methodLabel>usage</ua:methodLabel>
+                            <ua:requestURL>https://ord.feeds.api.rackspacecloud.com/sites/events</ua:requestURL>
+                            <ua:queryString>limit=10</ua:queryString>
                             <ua:tenantId>123456</ua:tenantId>
                             <ua:responseMessage>OK</ua:responseMessage>
                             <ua:userName>jackhandy</ua:userName>
-                            <ua:roles>xxx</ua:roles>
-                        </ua:auditData>
+                            <ua:roles>cloudfeeds-observer</ua:roles>
+                        </xx:unknownData>
                     </cadf:content>
                 </cadf:attachment>
             </cadf:attachments>

--- a/core_xsd/uae.xsd
+++ b/core_xsd/uae.xsd
@@ -19,27 +19,26 @@
     <xs:complexType name="AuditDataType">
         <xs:sequence>
             
-            <xs:element name="region" type="event:Region" default="GLOBAL" minOccurs="0" maxOccurs="1">
+            <xs:element name="region" type="event:Region" default="GLOBAL" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         <html:p>
                             Identifies the region, for example,
-                            DFW.  The attribute is optional, if it
-                            is not specified GLOBAL will be
-                            assumed.
+                            DFW. If the value of the element is 
+                            empty GLOBAL will be assumed.
                         </html:p>
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
             
-            <xs:element name="dataCenter" type="event:DC"  default="GLOBAL" minOccurs="0" maxOccurs="1">
+            <xs:element name="dataCenter" type="event:DC"  default="GLOBAL" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         <html:p>
                             Identifies the datacenter of the
-                            event, for example, DFW3.  The
-                            attribute is optional, if it is not
-                            specified GLOBAL will be assumed.
+                            event, for example, DFW3.  If the
+                            value of the element is empty
+                            GLOBAL will be assumed.
                         </html:p>
                     </xs:documentation>
                 </xs:annotation>
@@ -96,13 +95,14 @@
                 <xs:annotation>
                     <xs:documentation>
                         <html:p>
-                            
+                            An optional field containing the response
+                            message.
                         </html:p>
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
             
-            <xs:element name="userName" type="xs:string" minOccurs="1" maxOccurs="1">
+            <xs:element name="userName" type="NonEmptyString" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         <html:p>
@@ -118,14 +118,24 @@
                 <xs:annotation>
                     <xs:documentation>
                         <html:p>
-                            Comma separated list of roles
+
                         </html:p>
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
             
         </xs:sequence>
-        
+
+        <xs:attribute name="version" type="xs:string" use="required" fixed="1">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>
+                        The version of the audit data.
+                    </html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+
         <xs:assert vc:minVersion="1.1" 
             test="if (ua:dataCenter = ('DFW1','DFW2','DFW3')) then (ua:region = 'DFW') else
             if (ua:dataCenter = 'HKG1') then (ua:region = 'HKG') else

--- a/message_samples/feedsaccess/xml/feeds-user-acess-event-v1-entry.xml
+++ b/message_samples/feedsaccess/xml/feeds-user-acess-event-v1-entry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?atom feed="functest1/events"?>
+<?atom feed="feeds_access/events functest1/events"?>
 <atom:entry xmlns:atom="http://www.w3.org/2005/Atom"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns="http://www.w3.org/2001/XMLSchema">
@@ -8,18 +8,18 @@
         <cadf:event xmlns:cadf="http://schemas.dmtf.org/cloud/audit/1.0/event"
                     xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
                     xmlns:ua="http://feeds.api.rackspacecloud.com/cadf/user-access-event"
-                    id="6fa234aea93f38c26fa234aea93f38c2"
+                    id="6fa234aea93f38c26fa234aea93f38c4"
                     eventType="activity"
                     typeURI="http://schemas.dmtf.org/cloud/audit/1.0/event"
                     eventTime="2015-03-12T13:20:00-05:00"
-                    action="create/post"
+                    action="read/get"
                     outcome="success">
             <!--racker -->
             <cadf:initiator id="10.1.2.3" typeURI="network/node" name="jackhandy">
                 <cadf:host address="10.1.2.3" agent="curl/7.8 (i386-redhat-linux-gnu) libcurl 7.8" />
             </cadf:initiator>
-            <cadf:target id="x.x.x.x" typeURI="service" name="IDM" >
-                <cadf:host address="lon.identity.api.rackspacecloud.com" />
+            <cadf:target id="ord.feeds.api.rackspacecloud.com" typeURI="service" name="feeds" >
+                <cadf:host address="ord.feeds.api.rackspacecloud.com" />
             </cadf:target>
             <cadf:attachments>
                 <cadf:attachment name="auditData" contentType="ua:auditData">
@@ -27,18 +27,18 @@
                         <ua:auditData version="1">
                             <ua:region>DFW</ua:region>
                             <ua:dataCenter>DFW1</ua:dataCenter>
-                            <ua:methodLabel>createToken</ua:methodLabel>
-                            <ua:requestURL>https://lon.identity.api.rackspacecloud.com/v2.0/tokens</ua:requestURL>
-                            <ua:queryString></ua:queryString>
+                            <ua:methodLabel>usage</ua:methodLabel>
+                            <ua:requestURL>https://ord.feeds.api.rackspacecloud.com/sites/events</ua:requestURL>
+                            <ua:queryString>limit=10</ua:queryString>
                             <ua:tenantId>123456</ua:tenantId>
                             <ua:responseMessage>OK</ua:responseMessage>
                             <ua:userName>jackhandy</ua:userName>
-                            <ua:roles>xxx</ua:roles>
+                            <ua:roles>cloudfeeds-observer</ua:roles>
                         </ua:auditData>
                     </cadf:content>
                 </cadf:attachment>
             </cadf:attachments>
-            <cadf:observer id="IDM-1-1" name="repose-6.1.1.1" typeURI="service/security">
+            <cadf:observer id="feeds-1-1" name="repose-7.1.1.1" typeURI="service/security">
                 <cadf:host address="repose" />
             </cadf:observer>
             <cadf:reason reasonCode="200"

--- a/message_samples/feedsaccess/xml/feeds-user-acess-event-v1-no-region-no-dc.xml
+++ b/message_samples/feedsaccess/xml/feeds-user-acess-event-v1-no-region-no-dc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?atom feed="functest1/events"?>
+<?atom feed="feeds_access/events functest1/events"?>
 <atom:entry xmlns:atom="http://www.w3.org/2005/Atom"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns="http://www.w3.org/2001/XMLSchema">
@@ -8,37 +8,39 @@
         <cadf:event xmlns:cadf="http://schemas.dmtf.org/cloud/audit/1.0/event"
                     xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
                     xmlns:ua="http://feeds.api.rackspacecloud.com/cadf/user-access-event"
-                    id="6fa234aea93f38c26fa234aea93f38c2"
+                    id="6fa234aea93f38c26fa234aea93f38c4"
                     eventType="activity"
                     typeURI="http://schemas.dmtf.org/cloud/audit/1.0/event"
                     eventTime="2015-03-12T13:20:00-05:00"
-                    action="create/post"
+                    action="read/get"
                     outcome="success">
             <!--racker -->
             <cadf:initiator id="10.1.2.3" typeURI="network/node" name="jackhandy">
                 <cadf:host address="10.1.2.3" agent="curl/7.8 (i386-redhat-linux-gnu) libcurl 7.8" />
             </cadf:initiator>
-            <cadf:target id="x.x.x.x" typeURI="service" name="IDM" >
-                <cadf:host address="lon.identity.api.rackspacecloud.com" />
+            <cadf:target id="ord.feeds.api.rackspacecloud.com" typeURI="service" name="feeds" >
+                <cadf:host address="ord.feeds.api.rackspacecloud.com" />
             </cadf:target>
             <cadf:attachments>
                 <cadf:attachment name="auditData" contentType="ua:auditData">
                     <cadf:content>
                         <ua:auditData version="1">
-                            <ua:region>DFW</ua:region>
-                            <ua:dataCenter>DFW1</ua:dataCenter>
-                            <ua:methodLabel>createToken</ua:methodLabel>
-                            <ua:requestURL>https://lon.identity.api.rackspacecloud.com/v2.0/tokens</ua:requestURL>
-                            <ua:queryString></ua:queryString>
+                            <!-- GLOBAL will be added -->
+                            <ua:region />
+                            <!-- GLOBAL will be added -->
+                            <ua:dataCenter />
+                            <ua:methodLabel>usage</ua:methodLabel>
+                            <ua:requestURL>https://ord.feeds.api.rackspacecloud.com/sites/events</ua:requestURL>
+                            <ua:queryString>limit=10</ua:queryString>
                             <ua:tenantId>123456</ua:tenantId>
                             <ua:responseMessage>OK</ua:responseMessage>
                             <ua:userName>jackhandy</ua:userName>
-                            <ua:roles>xxx</ua:roles>
+                            <ua:roles>cloudfeeds-observer</ua:roles>
                         </ua:auditData>
                     </cadf:content>
                 </cadf:attachment>
             </cadf:attachments>
-            <cadf:observer id="IDM-1-1" name="repose-6.1.1.1" typeURI="service/security">
+            <cadf:observer id="feeds-1-1" name="repose-7.1.1.1" typeURI="service/security">
                 <cadf:host address="repose" />
             </cadf:observer>
             <cadf:reason reasonCode="200"

--- a/message_samples/feedsaccess/xml/feeds-user-acess-event-v1-respose.xml
+++ b/message_samples/feedsaccess/xml/feeds-user-acess-event-v1-respose.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<atom:entry xmlns:atom="http://www.w3.org/2005/Atom" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <atom:id>urn:uuid:6fa234aea93f38c26fa234aea93f38c4</atom:id>
+    <atom:category term="tid:5821027"/>
+    <atom:category term="rgn:DFW"/>
+    <atom:category term="dc:DFW1"/>
+    <atom:category term="username:jackhandy"/>
+    <atom:title type="text">UserAccessEvent</atom:title>
+    <atom:content type="application/xml">
+        <cadf:event xmlns:cadf="http://schemas.dmtf.org/cloud/audit/1.0/event" xmlns:ua="http://feeds.api.rackspacecloud.com/cadf/user-access-event" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" action="read/get" eventTime="2015-03-12T13:20:00-05:00" eventType="activity" id="6fa234aea93f38c26fa234aea93f38c4" outcome="success" typeURI="http://schemas.dmtf.org/cloud/audit/1.0/event">
+            <cadf:initiator id="10.1.2.3" name="jackhandy" typeURI="network/node">
+                <cadf:host address="10.1.2.3" agent="curl/7.8 (i386-redhat-linux-gnu) libcurl 7.8"/>
+            </cadf:initiator>
+            <cadf:target id="ord.feeds.api.rackspacecloud.com" name="feeds" typeURI="service">
+                <cadf:host address="ord.feeds.api.rackspacecloud.com"/>
+            </cadf:target>
+            <cadf:attachments>
+                <cadf:attachment contentType="ua:auditData" name="auditData">
+                    <cadf:content>
+                        <ua:auditData version="1">
+                            <ua:region>DFW</ua:region>
+                            <ua:dataCenter>DFW1</ua:dataCenter>
+                            <ua:methodLabel>usage</ua:methodLabel>
+                            <ua:requestURL>https://ord.feeds.api.rackspacecloud.com/sites/events</ua:requestURL>
+                            <ua:queryString>limit=10</ua:queryString>
+                            <ua:tenantId>5821027</ua:tenantId>
+                            <ua:responseMessage>OK</ua:responseMessage>
+                            <ua:userName>jackhandy</ua:userName>
+                            <ua:roles>cloudfeeds-observer</ua:roles>
+                        </ua:auditData>
+                    </cadf:content>
+                </cadf:attachment>
+            </cadf:attachments>
+            <cadf:observer id="feeds-1-1" name="repose-7.1.1.1" typeURI="service/security">
+                <cadf:host address="repose"/>
+            </cadf:observer>
+            <cadf:reason reasonCode="200" reasonType="http://www.iana.org/assignments/http-status-codes/http-status-codes.xml"/>
+        </cadf:event>
+    </atom:content>
+    <atom:link href="https://atom-chan5120-n03.dev.ord1.us.ci.rackspace.net/feeds_access/events/entries/urn:uuid:6fa234aea93f38c26fa234aea93f38c4" rel="self"/>
+    <atom:updated>2015-04-22T17:22:53.094Z</atom:updated>
+    <atom:published>2015-04-22T17:22:53.094Z</atom:published>
+</atom:entry>

--- a/src/docbkx/api-operations-external.xml
+++ b/src/docbkx/api-operations-external.xml
@@ -54,6 +54,13 @@
             <resource href="../../allfeeds.wadl#dbaas_events_getEntry_CloudDatabaseTenant"/>
         </resources>
     </section>
+    <section xml:id="feedsaccess.product">
+        <title>Feeds User Access Events</title>
+        <resources xmlns="http://wadl.dev.java.net/2009/02">
+            <resource href="../../allfeeds.wadl#feedsaccess_events_tenanted_feed"/>
+            <resource href="../../allfeeds.wadl#feedsaccess_events_getEntry_UserAccessEventTenant"/>
+        </resources>
+    </section>
     <section xml:id="files.product">
         <title>Cloud Files</title>
         <resources xmlns="http://wadl.dev.java.net/2009/02">
@@ -112,5 +119,4 @@
             <resource href="../../allfeeds.wadl#glance_events_getEntry_GlanceTenant"/>
         </resources>
     </section>
-  
 </chapter>

--- a/src/docbkx/api-operations-internal.xml
+++ b/src/docbkx/api-operations-internal.xml
@@ -111,6 +111,13 @@
             <resource href="../../allfeeds.wadl#ebs_events_getEntry_EBS"/>
         </resources>
     </section>
+    <section xml:id="feedsaccess.product">
+        <title>Feeds User Access Events</title>
+        <resources xmlns="http://wadl.dev.java.net/2009/02">
+            <resource href="../../allfeeds.wadl#feedsaccess_events"/>
+            <resource href="../../allfeeds.wadl#feedsaccess_events_getEntry_UserAccessEvent"/>
+        </resources>
+    </section>
   <section xml:id="files.product">
     <title>Cloud Files</title>
     <resources xmlns="http://wadl.dev.java.net/2009/02">

--- a/wadl/cadf.wadl
+++ b/wadl/cadf.wadl
@@ -1,0 +1,794 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:xs="http://www.w3.org/2001/XMLSchema"
+             xmlns:db="http://docbook.org/ns/docbook"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:atom="http://www.w3.org/2005/Atom"
+             xmlns:wadl="http://wadl.dev.java.net/2009/02"
+             xmlns:cldfeeds="http://docs.rackspace.com/api/cloudfeeds"
+             xmlns:error="http://docs.rackspace.com/core/error"
+             xmlns:event="http://docs.rackspace.com/core/event"
+             xmlns:cadf="http://schemas.dmtf.org/cloud/audit/1.0/event"
+             xmlns:ua="http://feeds.api.rackspacecloud.com/cadf/user-access-event"
+             xmlns:xi="http://www.w3.org/2001/XInclude">
+
+    <resource_type id="UserAccessEvent">
+        <method id="addUserAccessEventEntry" name="POST" rax:roles="cloudfeeds:service-admin">
+            <wadl:doc title="Add User Access Event" xmlns="http://docbook.org/ns/docbook">
+                <para role="shortdesc">
+                    Add user access event.
+                </para>
+                <example>
+                    <title>Specifies the message for a Cloud Feeds User Access Event</title>
+                    <informaltable frame="all"><?dbhtml table-width="100%"?><tgroup cols="4">
+                        <colspec colname="c1" colnum="1" colwidth="3*"/>
+                        <colspec colname="c2" colnum="2" colwidth="5.39*"/>
+                        <colspec colname="c3" colnum="3" colwidth="2*"/>
+                        <colspec colname="c4" colnum="4" colwidth="1.5*"/>
+                        <thead>
+                            <row>
+                                <entry>Element Name</entry>
+                                <entry>Description</entry>
+                                <entry>Type</entry>
+                                <entry>Optionality</entry>
+                            </row>
+                        </thead>
+                        <tbody>
+                            <row>
+                                <entry>
+                                    <para>
+                                        <code>region</code>
+                                    </para>
+                                </entry>
+                                <entry>
+                                    <para>
+                                        Identifies the region, for example,
+                                        DFW. If the value of the element is
+                                        empty GLOBAL will be assumed.
+                                    </para>
+                                </entry>
+                                <entry>
+                                    <para>string</para>
+                                </entry>
+                                <entry>
+                                    <para>Required</para>
+                                </entry>
+                            </row>
+                            <row>
+                                <entry>
+                                    <para>
+                                        <code>datacenter</code>
+                                    </para>
+                                </entry>
+                                <entry>
+                                    <para>
+                                        Identifies the datacenter of the
+                                        event, for example, DFW3.  If the
+                                        value of the element is empty
+                                        GLOBAL will be assumed.
+                                    </para>
+                                </entry>
+                                <entry>
+                                    <para>string</para>
+                                </entry>
+                                <entry>
+                                    <para>Required</para>
+                                </entry>
+                            </row>
+                            <row>
+                                <entry>
+                                    <para>
+                                        <code>methodLabel</code>
+                                    </para>
+                                </entry>
+                                <entry>
+                                    <para>
+                                        An optional field to indicate the method
+                                        used for the request.
+                                    </para>
+                                </entry>
+                                <entry>
+                                    <para>string</para>
+                                </entry>
+                                <entry>
+                                    <para>Optional</para>
+                                </entry>
+                            </row>
+                            <row>
+                                <entry>
+                                    <para>
+                                        <code>requestURL</code>
+                                    </para>
+                                </entry>
+                                <entry>
+                                    <para>
+                                        Request url with any query string truncated.
+                                    </para>
+                                </entry>
+                                <entry>
+                                    <para>string</para>
+                                </entry>
+                                <entry>
+                                    <para>Required</para>
+                                </entry>
+                            </row>
+                            <row>
+                                <entry>
+                                    <para>
+                                        <code>queryString</code>
+                                    </para>
+                                </entry>
+                                <entry>
+                                    <para>
+                                        An optional field. Query string is the part of
+                                        a uri containing data which is added to a base uri.
+                                    </para>
+                                </entry>
+                                <entry>
+                                    <para>string</para>
+                                </entry>
+                                <entry>
+                                    <para>Optional</para>
+                                </entry>
+                            </row>
+                            <row>
+                                <entry>
+                                    <para>
+                                        <code>tenantId</code>
+                                    </para>
+                                </entry>
+                                <entry>
+                                    <para>
+                                        Identifies the tenant ID.
+                                    </para>
+                                </entry>
+                                <entry>
+                                    <para>string</para>
+                                </entry>
+                                <entry>
+                                    <para>Required</para>
+                                </entry>
+                            </row>
+                            <row>
+                                <entry>
+                                    <para>
+                                        <code>responseMessage</code>
+                                    </para>
+                                </entry>
+                                <entry>
+                                    <para>
+                                        An optional field containing the response
+                                        message.
+                                    </para>
+                                </entry>
+                                <entry>
+                                    <para>string</para>
+                                </entry>
+                                <entry>
+                                    <para>Optional</para>
+                                </entry>
+                            </row>
+                            <row>
+                                <entry>
+                                    <para>
+                                        <code>userName</code>
+                                    </para>
+                                </entry>
+                                <entry>
+                                    <para>
+                                        The username that the initiator is acting on
+                                        behalf of (which might be themselves)
+                                    </para>
+                                </entry>
+                                <entry>
+                                    <para>string</para>
+                                </entry>
+                                <entry>
+                                    <para>Required</para>
+                                </entry>
+                            </row>
+                            <row>
+                                <entry>
+                                    <para>
+                                        <code>roles</code>
+                                    </para>
+                                </entry>
+                                <entry>
+                                    <para>
+                                        Comma separated list of roles
+                                    </para>
+                                </entry>
+                                <entry>
+                                    <para>string</para>
+                                </entry>
+                                <entry>
+                                    <para>Required</para>
+                                </entry>
+                            </row>
+                        </tbody>
+                    </tgroup>
+                    </informaltable>
+                    <para>
+                        <emphasis role="bold">XML Sample</emphasis>
+                        <programlisting language="xml">
+                        </programlisting>
+                    </para>
+                    <para>
+                        <emphasis role="bold">JSON Sample</emphasis>
+                        <programlisting language="json"/>
+                    </para>
+                </example>
+            </wadl:doc>
+            <request>
+                <representation mediaType="application/atom+xml" element="atom:entry">
+                    <param name="uae"
+                           style="plain"
+                           required="true"
+                           path="/atom:entry/atom:content/cadf:event/cadf:attachments/cadf:attachment/cadf:content/ua:auditData and /atom:entry/atom:content/cadf:event/cadf:attachments/cadf:attachment/cadf:content/ua:auditData[@version = '1']"
+                           rax:message="This feed only allows CADF events. The version and namespace of the CADF attachment content should correspond to user access events." />
+                    <param name="forbid-event-error"
+                           style="plain"
+                           required="true"
+                           path="not(/atom:entry/atom:content/error:eventError)"
+                           rax:message="eventErrors are not allowed in this feed."/>
+                    <rax:preprocess href="atom_hopper_pre.xsl"/>
+                </representation>
+            </request>
+            <response status="201">
+                <representation mediaType="application/atom+xml"/>
+            </response>
+            <response status="400 401 409 500 503">
+                <representation mediaType="application/xml"/>
+            </response>
+        </method>
+        <resource path="entries/{id}" id="getEntry_UserAccessEvent">
+            <param name="id" type="xs:anyURI" style="template">
+                <doc>urn:uuid:676f3860-447c-40a3-8f61-9791819cc82f</doc>
+            </param>
+            <method id="getEntryUserAccessEvent" name="GET">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                        xmlns:_0="http://wadl.dev.java.net/2009/02"
+                        xml:lang="EN"
+                        title="Get User Access Event by Entry">
+                    <para role="shortdesc">This http request fetches one particular event whose ID is listed in the URI.</para>
+                    <example>
+                        <title>Specifies the message for a Cloud Feeds User Access Event</title>
+                        <informaltable frame="all"><?dbhtml table-width="100%"?><tgroup cols="4">
+                            <colspec colname="c1" colnum="1" colwidth="3*"/>
+                            <colspec colname="c2" colnum="2" colwidth="5.39*"/>
+                            <colspec colname="c3" colnum="3" colwidth="2*"/>
+                            <colspec colname="c4" colnum="4" colwidth="1.5*"/>
+                            <thead>
+                                <row>
+                                    <entry>Element Name</entry>
+                                    <entry>Description</entry>
+                                    <entry>Type</entry>
+                                    <entry>Optionality</entry>
+                                </row>
+                            </thead>
+                            <tbody>
+                                <row>
+                                    <entry>
+                                        <para>
+                                            <code>region</code>
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>
+                                            Identifies the region, for example,
+                                            DFW. If the value of the element is
+                                            empty GLOBAL will be assumed.
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>string</para>
+                                    </entry>
+                                    <entry>
+                                        <para>Required</para>
+                                    </entry>
+                                </row>
+                                <row>
+                                    <entry>
+                                        <para>
+                                            <code>datacenter</code>
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>
+                                            Identifies the datacenter of the
+                                            event, for example, DFW3.  If the
+                                            value of the element is empty
+                                            GLOBAL will be assumed.
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>string</para>
+                                    </entry>
+                                    <entry>
+                                        <para>Required</para>
+                                    </entry>
+                                </row>
+                                <row>
+                                    <entry>
+                                        <para>
+                                            <code>methodLabel</code>
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>
+                                            An optional field to indicate the method
+                                            used for the request.
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>string</para>
+                                    </entry>
+                                    <entry>
+                                        <para>Optional</para>
+                                    </entry>
+                                </row>
+                                <row>
+                                    <entry>
+                                        <para>
+                                            <code>requestURL</code>
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>
+                                            Request url with any query string truncated.
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>string</para>
+                                    </entry>
+                                    <entry>
+                                        <para>Required</para>
+                                    </entry>
+                                </row>
+                                <row>
+                                    <entry>
+                                        <para>
+                                            <code>queryString</code>
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>
+                                            An optional field. Query string is the part of
+                                            a uri containing data which is added to a base uri.
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>string</para>
+                                    </entry>
+                                    <entry>
+                                        <para>Optional</para>
+                                    </entry>
+                                </row>
+                                <row>
+                                    <entry>
+                                        <para>
+                                            <code>tenantId</code>
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>
+                                            Identifies the tenant ID.
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>string</para>
+                                    </entry>
+                                    <entry>
+                                        <para>Required</para>
+                                    </entry>
+                                </row>
+                                <row>
+                                    <entry>
+                                        <para>
+                                            <code>responseMessage</code>
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>
+                                            An optional field containing the response
+                                            message.
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>string</para>
+                                    </entry>
+                                    <entry>
+                                        <para>Optional</para>
+                                    </entry>
+                                </row>
+                                <row>
+                                    <entry>
+                                        <para>
+                                            <code>userName</code>
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>
+                                            The username that the initiator is acting on
+                                            behalf of (which might be themselves)
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>string</para>
+                                    </entry>
+                                    <entry>
+                                        <para>Required</para>
+                                    </entry>
+                                </row>
+                                <row>
+                                    <entry>
+                                        <para>
+                                            <code>roles</code>
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>
+                                            Comma separated list of roles
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>string</para>
+                                    </entry>
+                                    <entry>
+                                        <para>Required</para>
+                                    </entry>
+                                </row>
+                            </tbody>
+                        </tgroup>
+                        </informaltable>
+                        <para>
+                            <emphasis role="bold">XML Sample</emphasis>
+                                <programlisting language="xml">&lt;?xml version="1.0"?&gt;
+&lt;atom:entry xmlns:atom="http://www.w3.org/2005/Atom" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema"&gt;
+    &lt;atom:id&gt;urn:uuid:6fa234aea93f38c26fa234aea93f38c4&lt;/atom:id&gt;
+    &lt;atom:category term="tid:5821027"/&gt;
+    &lt;atom:category term="rgn:DFW"/&gt;
+    &lt;atom:category term="dc:DFW1"/&gt;
+    &lt;atom:category term="username:jackhandy"/&gt;
+    &lt;atom:title type="text"&gt;UserAccessEvent&lt;/atom:title&gt;
+    &lt;atom:content type="application/xml"&gt;
+        &lt;cadf:event xmlns:cadf="http://schemas.dmtf.org/cloud/audit/1.0/event" xmlns:ua="http://feeds.api.rackspacecloud.com/cadf/user-access-event" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" action="read/get" eventTime="2015-03-12T13:20:00-05:00" eventType="activity" id="6fa234aea93f38c26fa234aea93f38c4" outcome="success" typeURI="http://schemas.dmtf.org/cloud/audit/1.0/event"&gt;
+            &lt;cadf:initiator id="10.1.2.3" name="jackhandy" typeURI="network/node"&gt;
+                &lt;cadf:host address="10.1.2.3" agent="curl/7.8 (i386-redhat-linux-gnu) libcurl 7.8"/&gt;
+            &lt;/cadf:initiator&gt;
+            &lt;cadf:target id="ord.feeds.api.rackspacecloud.com" name="feeds" typeURI="service"&gt;
+                &lt;cadf:host address="ord.feeds.api.rackspacecloud.com"/&gt;
+            &lt;/cadf:target&gt;
+            &lt;cadf:attachments&gt;
+                &lt;cadf:attachment contentType="ua:auditData" name="auditData"&gt;
+                    &lt;cadf:content&gt;
+                        &lt;ua:auditData version="1"&gt;
+                            &lt;ua:region&gt;DFW&lt;/ua:region&gt;
+                            &lt;ua:dataCenter&gt;DFW1&lt;/ua:dataCenter&gt;
+                            &lt;ua:methodLabel&gt;usage&lt;/ua:methodLabel&gt;
+                            &lt;ua:requestURL&gt;https://ord.feeds.api.rackspacecloud.com/sites/events&lt;/ua:requestURL&gt;
+                            &lt;ua:queryString&gt;limit=10&lt;/ua:queryString&gt;
+                            &lt;ua:tenantId&gt;5821027&lt;/ua:tenantId&gt;
+                            &lt;ua:responseMessage&gt;OK&lt;/ua:responseMessage&gt;
+                            &lt;ua:userName&gt;jackhandy&lt;/ua:userName&gt;
+                            &lt;ua:roles&gt;cloudfeeds-observer&lt;/ua:roles&gt;
+                        &lt;/ua:auditData&gt;
+                    &lt;/cadf:content&gt;
+                &lt;/cadf:attachment&gt;
+            &lt;/cadf:attachments&gt;
+            &lt;cadf:observer id="feeds-1-1" name="repose-7.1.1.1" typeURI="service/security"&gt;
+                &lt;cadf:host address="repose"/&gt;
+            &lt;/cadf:observer&gt;
+            &lt;cadf:reason reasonCode="200" reasonType="http://www.iana.org/assignments/http-status-codes/http-status-codes.xml"/&gt;
+        &lt;/cadf:event&gt;
+    &lt;/atom:content&gt;
+    &lt;atom:link href="https://atom-chan5120-n03.dev.ord1.us.ci.rackspace.net/feeds_access/events/entries/urn:uuid:6fa234aea93f38c26fa234aea93f38c4" rel="self"/&gt;
+    &lt;atom:updated&gt;2015-04-22T17:22:53.094Z&lt;/atom:updated&gt;
+    &lt;atom:published&gt;2015-04-22T17:22:53.094Z&lt;/atom:published&gt;
+&lt;/atom:entry&gt;
+                            </programlisting>
+                        </para>
+                        <para>
+                            <emphasis role="bold">JSON Sample</emphasis>
+                            <programlisting language="json"/>
+                        </para>
+                    </example>
+                </wadl:doc>
+                <request>
+                    <param style="header"
+                           type="cldfeeds:AcceptHeaderType"
+                           rax:code="406"
+                           repeating="true"
+                           required="true"
+                           rax:message="getEntryUserAccessEvent: Accept header contains unsupported media types: application/*json"
+                           name="ACCEPT"/>
+                </request>
+                <response status="200">
+                    <representation mediaType="application/atom+xml"/>
+                </response>
+                <response status="400 401 409 500 503">
+                    <representation mediaType="application/xml"/>
+                </response>
+            </method>
+        </resource>
+    </resource_type>
+
+    <resource_type id="UserAccessEventTenant">
+        <resource path="{tid}/entries/{id}" id="getEntry_UserAccessEventTenant">
+            <param name="tid" type="xs:string" style="template">
+                <doc>tenant ID</doc>
+            </param>
+            <param name="id" type="xs:anyURI" style="template">
+                <doc>urn:uuid:676f3860-447c-40a3-8f61-9791819cc82f</doc>
+            </param>
+            <method id="getEntryUserAccessEventTenant" name="GET">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                        xmlns:_0="http://wadl.dev.java.net/2009/02"
+                        xml:lang="EN"
+                        title="Get User Access Event">
+                    <para role="shortdesc">This http request fetches one particular event whose ID is listed in the URI.</para>
+                    <example>
+                        <title>Specifies the message for a Cloud Feeds User Access Event</title>
+                        <informaltable frame="all"><?dbhtml table-width="100%"?><tgroup cols="4">
+                            <colspec colname="c1" colnum="1" colwidth="3*"/>
+                            <colspec colname="c2" colnum="2" colwidth="5.39*"/>
+                            <colspec colname="c3" colnum="3" colwidth="2*"/>
+                            <colspec colname="c4" colnum="4" colwidth="1.5*"/>
+                            <thead>
+                                <row>
+                                    <entry>Element Name</entry>
+                                    <entry>Description</entry>
+                                    <entry>Type</entry>
+                                    <entry>Optionality</entry>
+                                </row>
+                            </thead>
+                            <tbody>
+                                <row>
+                                    <entry>
+                                        <para>
+                                            <code>region</code>
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>
+                                            Identifies the region, for example,
+                                            DFW. If the value of the element is
+                                            empty GLOBAL will be assumed.
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>string</para>
+                                    </entry>
+                                    <entry>
+                                        <para>Required</para>
+                                    </entry>
+                                </row>
+                                <row>
+                                    <entry>
+                                        <para>
+                                            <code>datacenter</code>
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>
+                                            Identifies the datacenter of the
+                                            event, for example, DFW3.  If the
+                                            value of the element is empty
+                                            GLOBAL will be assumed.
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>string</para>
+                                    </entry>
+                                    <entry>
+                                        <para>Required</para>
+                                    </entry>
+                                </row>
+                                <row>
+                                    <entry>
+                                        <para>
+                                            <code>methodLabel</code>
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>
+                                            An optional field to indicate the method
+                                            used for the request.
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>string</para>
+                                    </entry>
+                                    <entry>
+                                        <para>Optional</para>
+                                    </entry>
+                                </row>
+                                <row>
+                                    <entry>
+                                        <para>
+                                            <code>requestURL</code>
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>
+                                            Request url with any query string truncated.
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>string</para>
+                                    </entry>
+                                    <entry>
+                                        <para>Required</para>
+                                    </entry>
+                                </row>
+                                <row>
+                                    <entry>
+                                        <para>
+                                            <code>queryString</code>
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>
+                                            An optional field. Query string is the part of
+                                            a uri containing data which is added to a base uri.
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>string</para>
+                                    </entry>
+                                    <entry>
+                                        <para>Optional</para>
+                                    </entry>
+                                </row>
+                                <row>
+                                    <entry>
+                                        <para>
+                                            <code>tenantId</code>
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>
+                                            Identifies the tenant ID.
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>string</para>
+                                    </entry>
+                                    <entry>
+                                        <para>Required</para>
+                                    </entry>
+                                </row>
+                                <row>
+                                    <entry>
+                                        <para>
+                                            <code>responseMessage</code>
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>
+                                            An optional field containing the response
+                                            message.
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>string</para>
+                                    </entry>
+                                    <entry>
+                                        <para>Optional</para>
+                                    </entry>
+                                </row>
+                                <row>
+                                    <entry>
+                                        <para>
+                                            <code>userName</code>
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>
+                                            The username that the initiator is acting on
+                                            behalf of (which might be themselves)
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>string</para>
+                                    </entry>
+                                    <entry>
+                                        <para>Required</para>
+                                    </entry>
+                                </row>
+                                <row>
+                                    <entry>
+                                        <para>
+                                            <code>roles</code>
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>
+                                            Comma separated list of roles
+                                        </para>
+                                    </entry>
+                                    <entry>
+                                        <para>string</para>
+                                    </entry>
+                                    <entry>
+                                        <para>Required</para>
+                                    </entry>
+                                </row>
+                            </tbody>
+                        </tgroup>
+                        </informaltable>
+                        <para>
+                            <emphasis role="bold">XML Sample</emphasis>
+                            <programlisting language="xml">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;atom:entry xmlns:atom="http://www.w3.org/2005/Atom" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema"&gt;
+    &lt;atom:id&gt;urn:uuid:6fa234aea93f38c26fa234aea93f38c4&lt;/atom:id&gt;
+    &lt;atom:category term="tid:5821027"/&gt;
+    &lt;atom:category term="rgn:DFW"/&gt;
+    &lt;atom:category term="dc:DFW1"/&gt;
+    &lt;atom:category term="username:jackhandy"/&gt;
+    &lt;atom:title type="text"&gt;UserAccessEvent&lt;/atom:title&gt;
+    &lt;atom:content type="application/xml"&gt;
+        &lt;cadf:event xmlns:cadf="http://schemas.dmtf.org/cloud/audit/1.0/event" xmlns:ua="http://feeds.api.rackspacecloud.com/cadf/user-access-event" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" action="read/get" eventTime="2015-03-12T13:20:00-05:00" eventType="activity" id="6fa234aea93f38c26fa234aea93f38c4" outcome="success" typeURI="http://schemas.dmtf.org/cloud/audit/1.0/event"&gt;
+            &lt;cadf:initiator id="10.1.2.3" name="jackhandy" typeURI="network/node"&gt;
+                &lt;cadf:host address="10.1.2.3" agent="curl/7.8 (i386-redhat-linux-gnu) libcurl 7.8"/&gt;
+            &lt;/cadf:initiator&gt;
+            &lt;cadf:target id="ord.feeds.api.rackspacecloud.com" name="feeds" typeURI="service"&gt;
+                &lt;cadf:host address="ord.feeds.api.rackspacecloud.com"/&gt;
+            &lt;/cadf:target&gt;
+            &lt;cadf:attachments&gt;
+                &lt;cadf:attachment contentType="ua:auditData" name="auditData"&gt;
+                    &lt;cadf:content&gt;
+                        &lt;ua:auditData version="1"&gt;
+                            &lt;ua:region&gt;DFW&lt;/ua:region&gt;
+                            &lt;ua:dataCenter&gt;DFW1&lt;/ua:dataCenter&gt;
+                            &lt;ua:methodLabel&gt;usage&lt;/ua:methodLabel&gt;
+                            &lt;ua:requestURL&gt;https://ord.feeds.api.rackspacecloud.com/sites/events&lt;/ua:requestURL&gt;
+                            &lt;ua:queryString&gt;limit=10&lt;/ua:queryString&gt;
+                            &lt;ua:tenantId&gt;5821027&lt;/ua:tenantId&gt;
+                            &lt;ua:responseMessage&gt;OK&lt;/ua:responseMessage&gt;
+                            &lt;ua:userName&gt;jackhandy&lt;/ua:userName&gt;
+                            &lt;ua:roles&gt;cloudfeeds-observer&lt;/ua:roles&gt;
+                        &lt;/ua:auditData&gt;
+                    &lt;/cadf:content&gt;
+                &lt;/cadf:attachment&gt;
+            &lt;/cadf:attachments&gt;
+            &lt;cadf:observer id="feeds-1-1" name="repose-7.1.1.1" typeURI="service/security"&gt;
+                &lt;cadf:host address="repose"/&gt;
+            &lt;/cadf:observer&gt;
+            &lt;cadf:reason reasonCode="200" reasonType="http://www.iana.org/assignments/http-status-codes/http-status-codes.xml"/&gt;
+        &lt;/cadf:event&gt;
+&lt;/atom:content&gt;
+&lt;atom:link href="https://atom-chan5120-n03.dev.ord1.us.ci.rackspace.net/feeds_access/events/5821027/entries/urn:uuid:6fa234aea93f38c26fa234aea93f38c4" rel="self"/&gt;
+&lt;atom:updated&gt;2015-04-22T17:22:53.094Z&lt;/atom:updated&gt;
+&lt;atom:published&gt;2015-04-22T17:22:53.094Z&lt;/atom:published&gt;
+&lt;/atom:entry&gt;
+                            </programlisting>
+                        </para>
+                        <para>
+                            <emphasis role="bold">JSON Sample</emphasis>
+                            <programlisting language="json"/>
+                        </para>
+                    </example>
+                </wadl:doc>
+                <request>
+                    <param style="header"
+                           type="cldfeeds:AcceptHeaderType"
+                           rax:code="406"
+                           repeating="true"
+                           required="true"
+                           rax:message="getEntryUserAccessEvent: Accept header contains unsupported media types: application/*json"
+                           name="ACCEPT"/>
+                </request>
+                <response status="200">
+                    <representation mediaType="application/atom+xml"/>
+                </response>
+                <response status="400 401 409 500 503">
+                    <representation mediaType="application/xml"/>
+                </response>
+            </method>
+        </resource>
+    </resource_type>
+
+    
+    
+</application>    


### PR DESCRIPTION
 - New feed, feeds_access/events feed for feeds UAE
 - Added version attribute for auditData
 - Updated sample xmls with version attribute
 - Updated api-operations with the new feed for docs
 - Changes to make region/datacenter required.