### PR TITLE
CF-447 Changes to allow content other than cadf:event type

### DIFF
--- a/bad_message_samples/feedsaccess/feeds-user-acess-event-v1-entry-invalid-content-non-cadf.xml
+++ b/bad_message_samples/feedsaccess/feeds-user-acess-event-v1-entry-invalid-content-non-cadf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?atom feed="feeds_access/events"?>
-<?expect code="400" message="Bad Content: This feed only allows CADF events. The version and namespace of the CADF attachment content should correspond to user access events."?>
+<?expect code="400" message="Bad Content: Product/Usage events are not allowed in this feed."?>
 <atom:entry xmlns="http://docs.rackspace.com/core/event"
             xmlns:cb-bin="http://docs.rackspace.com/usage/cloudbackup/bandwidthIn"
             xmlns:atom="http://www.w3.org/2005/Atom">

--- a/bad_message_samples/feedsaccess/feeds-user-acess-event-v1-entry-invalid-version.xml
+++ b/bad_message_samples/feedsaccess/feeds-user-acess-event-v1-entry-invalid-version.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?atom feed="feeds_access/events"?>
-<?expect code="400" message="Bad Content: This feed only allows CADF events. The version and namespace of the CADF attachment content should correspond to user access events."?>
+<?expect code="400" message="Bad Content: The version and namespace of the CADF attachment content should correspond to user access events."?>
 <atom:entry xmlns:atom="http://www.w3.org/2005/Atom"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns="http://www.w3.org/2001/XMLSchema">

--- a/bad_message_samples/feedsaccess/feeds-user-acess-event-v1-entry-unknown-content-type.xml
+++ b/bad_message_samples/feedsaccess/feeds-user-acess-event-v1-entry-unknown-content-type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?atom feed="feeds_access/events"?>
-<?expect code="400" message="Bad Content: This feed only allows CADF events. The version and namespace of the CADF attachment content should correspond to user access events."?>
+<?expect code="400" message="Bad Content: The version and namespace of the CADF attachment content should correspond to user access events."?>
 <atom:entry xmlns:atom="http://www.w3.org/2005/Atom"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns="http://www.w3.org/2001/XMLSchema"

--- a/message_samples/feedsaccess/xml/feeds-user-access-event-v1-random-content-response.xml
+++ b/message_samples/feedsaccess/xml/feeds-user-access-event-v1-random-content-response.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<atom:entry xmlns:atom="http://www.w3.org/2005/Atom" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <atom:title type="text">UserAccessEvent</atom:title>
+    <atom:content type="text">        Random content    </atom:content>
+    <atom:id>urn:uuid:37ef5f69-e4bd-40e1-89a4-7c3252783971</atom:id>
+    <atom:link href="https://atom-chan5120-n03.dev.ord1.us.ci.rackspace.net/feeds_access/events/entries/urn:uuid:37ef5f69-e4bd-40e1-89a4-7c3252783971" rel="self"/>
+    <atom:updated>2015-04-29T16:39:29.273Z</atom:updated>
+    <atom:published>2015-04-29T16:39:29.273Z</atom:published>
+</atom:entry>

--- a/message_samples/feedsaccess/xml/feeds-user-access-event-v1-random-content.xml
+++ b/message_samples/feedsaccess/xml/feeds-user-access-event-v1-random-content.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?atom feed="feeds_access/events functest1/events"?>
+<atom:entry xmlns:atom="http://www.w3.org/2005/Atom"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns="http://www.w3.org/2001/XMLSchema">
+    <atom:title>UserAccessEvent</atom:title>
+    <atom:content type="text">
+        Random content
+    </atom:content>
+</atom:entry>

--- a/wadl/cadf.wadl
+++ b/wadl/cadf.wadl
@@ -221,11 +221,16 @@
             </wadl:doc>
             <request>
                 <representation mediaType="application/atom+xml" element="atom:entry">
+                    <param name="cross_check"
+                           style="plain"
+                           required="true"
+                           rax:message="Product/Usage events are not allowed in this feed."
+                           path="not(/atom:entry/atom:content/event:event)"/>
                     <param name="uae"
                            style="plain"
                            required="true"
-                           path="/atom:entry/atom:content/cadf:event/cadf:attachments/cadf:attachment/cadf:content/ua:auditData and /atom:entry/atom:content/cadf:event/cadf:attachments/cadf:attachment/cadf:content/ua:auditData[@version = '1']"
-                           rax:message="This feed only allows CADF events. The version and namespace of the CADF attachment content should correspond to user access events." />
+                           path="if (/atom:entry/atom:content/cadf:event) then (/atom:entry/atom:content/cadf:event/cadf:attachments/cadf:attachment/cadf:content/ua:auditData and /atom:entry/atom:content/cadf:event/cadf:attachments/cadf:attachment/cadf:content/ua:auditData[@version = '1']) else true()"
+                           rax:message="The version and namespace of the CADF attachment content should correspond to user access events." />
                     <param name="forbid-event-error"
                            style="plain"
                            required="true"


### PR DESCRIPTION
Current product events allow content of type text. This PR is to make changes so that feeds_access also allows them.