### PR TITLE
CF-615: remove nova from being marked as cloudfeeds:private

### DIFF
--- a/message_samples/nova/json/cloudserversopenstack-nova-server-usage-v1-response.json
+++ b/message_samples/nova/json/cloudserversopenstack-nova-server-usage-v1-response.json
@@ -3,9 +3,6 @@
         "@type": "http://www.w3.org/2005/Atom",
         "category": [
             {
-                "term": "cloudfeeds:private"
-            },
-            {
                 "term": "tid:1234"
             },
             {

--- a/message_samples/nova/xml/cloudserversopenstack-nova-server-usage-v1-response.xml
+++ b/message_samples/nova/xml/cloudserversopenstack-nova-server-usage-v1-response.xml
@@ -18,7 +18,6 @@
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns="http://www.w3.org/2001/XMLSchema">
    <atom:id>urn:uuid:e53d007a-fc23-11e1-975c-cfa6b29bb814</atom:id>
-   <atom:category term="cloudfeeds:private"/>
    <atom:category term="tid:1234"/>
    <atom:category term="rgn:DFW"/>
    <atom:category term="dc:DFW1"/>

--- a/src/test/scala/transform-tests.scala
+++ b/src/test/scala/transform-tests.scala
@@ -177,31 +177,4 @@ class TransformSuite extends BaseUsageSuite {
     atomValidator.validate(req, response, chain)
     assert(getProcessedXML(req), "count(/atom:entry/atom:category[@term = 'cloudfiles.cdnbandwidth.usage']) = 0")
   }
-
-  test("Mark cloudserversopenstack.nova.server.usage with cloudfeeds:private category" ) {
-    val body = <atom:entry xmlns:atom="http://www.w3.org/2005/Atom">
-      <atom:title>Nagios Event</atom:title>
-      <atom:content type="application/xml">
-        <event xmlns="http://docs.rackspace.com/core/event"
-               xmlns:nova="http://docs.rackspace.com/event/nova"
-               version="1" id="e53d007a-fc23-11e1-975c-cfa6b29bb814"
-               resourceId="f37bca20-29c5-4e08-97f4-e47908887bc1" resourceName="testserver78193259535"
-               dataCenter="IAD3" region="IAD"
-               tenantId="231423"
-               startTime="2013-05-15T11:51:11Z" endTime="2013-05-16T11:51:11Z"
-               type="USAGE">
-          <nova:product version="1" serviceCode="CloudServersOpenStack"
-                        resourceType="SERVER" flavorId="3" flavorName="1024MB" status="ACTIVE"
-                        osLicenseType="RHEL" bandwidthIn="640034"
-                        bandwidthOut="345123"
-          />
-        </event>
-      </atom:content>
-    </atom:entry>
-
-    val req = request("POST", "/usagetest1/events", "application/atom+xml", body, SERVICE_ADMIN)
-    atomValidator.validate(req, response, chain)
-    assert(getProcessedXML(req), "/atom:entry/atom:category/@term = 'cloudfeeds:private'")
-
-  }
 }

--- a/wadl/atom_hopper_pre.xsl
+++ b/wadl/atom_hopper_pre.xsl
@@ -283,19 +283,6 @@
                 <xsl:value-of select="concat('urn:uuid:',$event/@id)"/>
             </xsl:element>
 
-            <!--
-              Mark event as private if necessary
-            -->
-            <!--
-              nova events will soon be posted, but not yet public for observers
-            -->
-            <xsl:if test="$eventType = 'cloudserversopenstack.nova.server.usage'">
-                <xsl:call-template name="addCategory">
-                    <xsl:with-param name="prefix" select="'cloudfeeds:'"/>
-                    <xsl:with-param name="term" select="'private'"/>
-                </xsl:call-template>
-            </xsl:if>
-
             <xsl:call-template name="addCategory">
                 <xsl:with-param name="term" select="$event/@tenantId"/>
                 <xsl:with-param name="prefix" select="'tid:'"/>


### PR DESCRIPTION
Remove Nova from being marked ```cloudfeeds:private```. I did not find any trace of Glance eventTypes being marked as ```cloudfeeds:private```