### PR TITLE
CF-948 added internal tag to all archiving content

### DIFF
--- a/src/docbkx/feeds-devguide.xml
+++ b/src/docbkx/feeds-devguide.xml
@@ -2554,7 +2554,7 @@
         </section>
     </chapter>    
     <xi:include href="feeds-archiving.xml" security="internal"></xi:include>
-    <xi:include href="api-operations-external.xml" security="internal"></xi:include>
-    <xi:include href="api-operations-internal.xml" security="internal"></xi:include>
+    <xi:include href="api-operations-external.xml"></xi:include>
+    <xi:include href="api-operations-internal.xml"></xi:include>
 
     </book>

--- a/src/docbkx/feeds-devguide.xml
+++ b/src/docbkx/feeds-devguide.xml
@@ -53,7 +53,7 @@
                 Interface (<abbrev>API</abbrev>). </para>
         </abstract>
         <revhistory>
-            <revision>
+            <revision security="internal">
                 <date>2015-04-28</date>
                 <revdescription>
                     <itemizedlist spacing="compact">
@@ -567,7 +567,7 @@
                     <para>In addition to token-based authentication Cloud Feeds also
                         supports basic authentication by using your Rackspace cloud account username
                         and API key.</para>
-                <para>
+                <para security="internal">
                     <important>
                         <para>Basic authentcation cannot be used for making requests against the
                                 <link linkend="Preferences_API">Archiving Configuration
@@ -2553,8 +2553,8 @@
                 </para></section>
         </section>
     </chapter>    
-    <xi:include href="feeds-archiving.xml"/>
-    <xi:include href="api-operations-external.xml"/>
-    <xi:include href="api-operations-internal.xml"/>
+    <xi:include href="feeds-archiving.xml" security="internal"></xi:include>
+    <xi:include href="api-operations-external.xml" security="internal"></xi:include>
+    <xi:include href="api-operations-internal.xml" security="internal"></xi:include>
 
     </book>


### PR DESCRIPTION
Added internal tag to all archiving content. The plan is to redeploy the dev guide without the archiving content to docs external and with the archiving content to docs internal.