### PR TITLE
CF-952: add servermill feed

### DIFF
--- a/allfeeds.wadl
+++ b/allfeeds.wadl
@@ -133,6 +133,9 @@
                   path="queues/events" 
                   type="wadl/feed.wadl#AtomFeed wadl/product.wadl#CloudQueues 
                         wadl/feed.wadl#TenantAtomFeed wadl/product.wadl#CloudQueuesTenant"/>
+        <resource id="servermill_events"
+                  path="servermill/events"
+                  type="wadl/feed.wadl#AtomFeed wadl/feed.wadl#Validated"/>
         <resource id="servers_events"
                   path="servers/events" 
                   type="wadl/feed.wadl#AtomFeedAllowJson 

--- a/src/docbkx/api-operations-internal.xml
+++ b/src/docbkx/api-operations-internal.xml
@@ -167,6 +167,12 @@
       <resource href="../../allfeeds.wadl#queues_events_getEntry_CloudQueues"/>
     </resources>
   </section>
+  <section xml:id="servermill.product">
+    <title>Server Mill</title>
+    <resources xmlns="http://wadl.dev.java.net/2009/02">
+      <resource href="../../allfeeds.wadl#servermill_events"/>
+    </resources>
+  </section>
   <section xml:id="servers.product">
     <title>Cloud Servers Legacy</title>
     <resources xmlns="http://wadl.dev.java.net/2009/02">


### PR DESCRIPTION
Adding the servermill feed in our wadl and doc. Per email from the ServerMill team, this feed can be consumed by customers. But in this PR, I am not adding the externally visible version of this feed, because we do not yet have a schema for it. 

I will add a task in the schema story to make sure the feed is available externally.