### PR TITLE
CF-962: remove /glance feed from observer's view

### DIFF
--- a/allfeeds.wadl
+++ b/allfeeds.wadl
@@ -84,7 +84,7 @@
                   type="wadl/feed.wadl#AtomFeed wadl/product.wadl#CloudFiles wadl/feed.wadl#TenantAtomFeed  wadl/product.wadl#CloudFilesTenant"/>
         <resource id="glance_events"
                   path="glance/events" 
-                  type="wadl/feed.wadl#AtomFeed wadl/product.wadl#Glance wadl/feed.wadl#TenantAtomFeed wadl/product.wadl#GlanceTenant"/>
+                  type="wadl/feed.wadl#AtomFeed wadl/product.wadl#Glance"/>
         <resource id="identity_events"
                   path="identity/events" 
                   type="wadl/feed.wadl#AtomFeed wadl/product.wadl#CloudIdentity wadl/feed.wadl#TenantAtomFeed wadl/product.wadl#CloudIdentityTenant"/>

--- a/src/docbkx/api-operations-external.xml
+++ b/src/docbkx/api-operations-external.xml
@@ -126,11 +126,4 @@
             <resource href="../../allfeeds.wadl#nova_events_getEntry_RHELTenant"/>
         </resources>
     </section>
-    <section xml:id="glance.product">
-        <title>Glance</title>
-        <resources xmlns="http://wadl.dev.java.net/2009/02">
-            <resource href="../../allfeeds.wadl#glance_events_tenanted_feed"/>
-            <resource href="../../allfeeds.wadl#glance_events_getEntry_GlanceTenant"/>
-        </resources>
-    </section>
 </chapter>


### PR DESCRIPTION
Per story, /glace feed is not to be exposed to Observers roles.