### PR TITLE
CF-997: for usage_summary, dont require serverID

### DIFF
--- a/bad_message_samples/backup/cloudbackup-license-usage-v3-missingServerID.xml
+++ b/bad_message_samples/backup/cloudbackup-license-usage-v3-missingServerID.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?atom feed="backup/events"?> <!-- ignore <?atom..?>, used for testing -->
+<?expect code="400" message="serverID"?>
 <atom:entry xmlns="http://docs.rackspace.com/core/event"
             xmlns:cb-lic="http://docs.rackspace.com/usage/cloudbackup/license"
             xmlns:atom="http://www.w3.org/2005/Atom">
     <atom:content type="application/xml">
-        <event eventTime="2014-01-24T10:19:52Z"
+        <event endTime="2012-06-15T10:19:52Z" startTime="2012-06-14T10:19:52Z"
                region="DFW" dataCenter="DFW1" type="USAGE_SNAPSHOT"
-               id="8d89673c-c989-22e1-895a-0b3d632a8a89"
+               id="8d89673c-c989-33e1-895a-0b3d632a8a89"
                resourceId="3863d42a-ec9a-11e1-8e12-df8baa3ca440"
-               tenantId="123456" version="1">
+               tenantId="1234567" version="1">
             <cb-lic:product version="3" serviceCode="CloudBackup"
-                            serverID="9445"
                             serverName="SomeServerName"
                             resourceType="AGENT"/>
         </event>

--- a/message_samples/backup/json/cloudbackup-license-agent-usage_snapshot-v3-summary-entry-noServerID.json
+++ b/message_samples/backup/json/cloudbackup-license-agent-usage_snapshot-v3-summary-entry-noServerID.json
@@ -1,0 +1,28 @@
+{
+    "entry": {
+        "@type": "http://www.w3.org/2005/Atom",
+        "content": {
+            "event": {
+                "@type": "http://docs.rackspace.com/core/event",
+                "dataCenter": "DFW1",
+                "duration": "PT10M",
+                "endTime": "2013-03-16T11:51:11Z",
+                "id": "e53d007a-fc23-11e1-975c-cfa6b29bb814",
+                "product": {
+                    "@type": "http://docs.rackspace.com/usage/cloudbackup/license",
+                    "resourceType": "AGENT",
+                    "serviceCode": "CloudBackup",
+                    "version": "3"
+                },
+                "rackspaceAccountNumber": "020-1234",
+                "region": "DFW",
+                "resourceId": "4a2b42f4-6c63-11e1-815b-7fcbcf67f549",
+                "startTime": "2013-03-15T11:51:11Z",
+                "tenantId": "1234",
+                "type": "USAGE_SUMMARY",
+                "version": "3"
+            }
+        },
+        "title": "CloudBackup Summary"
+    }
+}

--- a/message_samples/backup/xml/cloudbackup-license-agent-usage_snapshot-v3-summary-entry-noServerID.xml
+++ b/message_samples/backup/xml/cloudbackup-license-agent-usage_snapshot-v3-summary-entry-noServerID.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?atom feed="usagesummary/backup/events"?>
+<atom:entry xmlns:atom="http://www.w3.org/2005/Atom"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns="http://www.w3.org/2001/XMLSchema">
+   <atom:title>CloudBackup Summary</atom:title>
+   <atom:content type="application/xml">
+      <event xmlns="http://docs.rackspace.com/core/event"
+             xmlns:sample="http://docs.rackspace.com/usage/cloudbackup/license"
+             id="e53d007a-fc23-11e1-975c-cfa6b29bb814"
+             version="3"
+             resourceId="4a2b42f4-6c63-11e1-815b-7fcbcf67f549"
+             tenantId="1234"
+             rackspaceAccountNumber="020-1234"
+             startTime="2013-03-15T11:51:11Z"
+             endTime="2013-03-16T11:51:11Z"
+             duration="PT10M"
+             type="USAGE_SUMMARY"
+             dataCenter="DFW1"
+             region="DFW">
+         <sample:product serviceCode="CloudBackup" version="3" resourceType="AGENT"/>
+      </event>
+   </atom:content>
+</atom:entry>

--- a/sample_product_schemas/cloudbackupLicense.xml
+++ b/sample_product_schemas/cloudbackupLicense.xml
@@ -31,8 +31,9 @@
             <attribute name="external" type="boolean" use="optional" default="false">
                 If this value is set to true, the server where the agent is installed is external to Rackspace.
             </attribute>
-            <xpathAssertion test="if (not(xsd:boolean(@external))) then @serverID else true()">
-                If the server is NOT external, then the serverID attribute is required.
+            <xpathAssertion test="if (not(xsd:boolean($product/@external)) and ($event/@type != 'USAGE_SUMMARY')) then ($product/@serverID) else true()"
+                            scope="entry">
+                If the server is NOT external and event is not USAGE_SUMMARY, then the serverID attribute is required.
             </xpathAssertion>
     </productSchema>
 </alternatives>


### PR DESCRIPTION
This should fix Issue #476 for just the Cloud Backup License usage summary events. This does not fix the Cloud Sites issue mentioned there. 