### PR TITLE
CF-979 - JSON Samples

### DIFF
--- a/wadl/cadf.wadl
+++ b/wadl/cadf.wadl
@@ -208,15 +208,6 @@
                         </tbody>
                     </tgroup>
                     </informaltable>
-                    <para>
-                        <emphasis role="bold">XML Sample</emphasis>
-                        <programlisting language="xml">
-                        </programlisting>
-                    </para>
-                    <para>
-                        <emphasis role="bold">JSON Sample</emphasis>
-                        <programlisting language="json"/>
-                    </para>
                 </example>
             </wadl:doc>
             <request>


### PR DESCRIPTION
Removing needless sample headings.  This should clean things up for all UAE docs.  The other events' extra blank headings are handled in a later story.
