### PR TITLE
CF-1000: add assert to make sure we don't have empty entry list object

### DIFF
--- a/src/test/scala/Xml2JsonSuite.scala
+++ b/src/test/scala/Xml2JsonSuite.scala
@@ -179,6 +179,9 @@ class Xml2JsonSuite extends BaseUsageSuite {
         assert(feedObject.get("link").get != null, "should have 'link' elements")
         val linkObjects = feedObject.get("link").get.asInstanceOf[List[Map[String, Any]]]
         assert(linkObjects.size == 3, "should have 3 link elements")
+
+        // check for entries
+        assert(feedObject.get("entry") == None, "should not have entry")
       }
     })
 


### PR DESCRIPTION
when translating xml empty feed to its JSON equivalent.