### PR TITLE
CF-618 - Feeds UAE env: configure HERP

### DIFF
--- a/core_xsd/cadf.xsd
+++ b/core_xsd/cadf.xsd
@@ -149,7 +149,7 @@
       </xs:annotation>
       <xs:simpleType>
         <xs:restriction base="xs:string">
-          <xs:pattern value="read.*|create.*"/>
+          <xs:pattern value="read.*|create.*|update.*"/>
         </xs:restriction>
       </xs:simpleType>
     </xs:attribute>

--- a/core_xsd/uae.xsd
+++ b/core_xsd/uae.xsd
@@ -81,7 +81,7 @@
                 </xs:annotation>
             </xs:element>
             
-            <xs:element name="tenantId" type="NonEmptyString" minOccurs="1" maxOccurs="1">
+            <xs:element name="tenantId" type="xs:string" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         <html:p>
@@ -102,7 +102,7 @@
                 </xs:annotation>
             </xs:element>
             
-            <xs:element name="userName" type="NonEmptyString" minOccurs="1" maxOccurs="1">
+            <xs:element name="userName" type="xs:string" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         <html:p>
@@ -113,7 +113,7 @@
                 </xs:annotation>
             </xs:element>
             
-            <xs:element name="roles" type="NonEmptyString" minOccurs="1" maxOccurs="1">
+            <xs:element name="roles" type="xs:string" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         <html:p>


### PR DESCRIPTION
Updating the CADF & user access event schemas to allow the following:
- CADF: allow action to be "update/post"
- UAE: tenantId can be empty string
- UAE: userName can be empty string
- UAE: roles can be empty string

These updates were required because I found that the HERP filter has been generating the following events, which have these properties:

**When a user without cloudfeeds:service-admin role attempts to POST to a tenant feed**
```
<cadf:event action="update/post" eventTime="2015-08-05T17:19:07.940+00:00" eventType="activity" id="eb03f19f-7320-4516-905e-d0fbdba43446" outcome="failure" typeURI="http://schemas.dmtf.org/cloud/audit/1.0/event" xsi:schemaLocation="http://schemas.dmtf.org/cloud/audit/1.0/event user-access-cadf.xsd">
<cadf:initiator id="cfeedstestadminrole" name="cfeedstestadminrole" typeURI="network/node">
<cadf:host address="10.1.68.228" agent="Apache-HttpClient/4.3 (java 1.5)" />
</cadf:initiator>
<cadf:target id="10.23.83.80" name="cloudFeeds" typeURI="service">
<cadf:host address="10.23.83.80" />
</cadf:target>
<cadf:attachments>
<cadf:attachment contentType="ua:auditData" name="auditData">
<cadf:content>
 <ua:auditData version="1">
<ua:region>ORD</ua:region>
<ua:dataCenter>ORD1</ua:dataCenter>
<ua:methodLabel />
<ua:requestURL>http://10.23.83.80:9090/usagesummaryrecovery/events/5821027</ua:requestURL>
<ua:queryString />
<ua:tenantId>5821027</ua:tenantId>
<ua:responseMessage>NOT_FOUND</ua:responseMessage>
<ua:userName>cfeedstestadminrole</ua:userName>
<ua:roles>admin object-store:default compute:default identity:default</ua:roles>
 </ua:auditData>
</cadf:content>
</cadf:attachment>
</cadf:attachments>
<cadf:observer id="cloudFeeds-repose-repose_localhost" name="repose" typeURI="service/security">
<cadf:host address="repose_localhost" />
</cadf:observer>
<cadf:reason reasonCode="404" reasonType="http://www.iana.org/assignments/http-status-codes/http-status-codes.xml" />
 </cadf:event>
```

**When an unauthenticated user attempts to access as tenant feed**
```
 <cadf:event action="read/get" eventTime="2015-08-05T17:24:55.477+00:00" eventType="activity" id="c2a1859d-af14-4be8-aecf-c9844e960c6a" outcome="failure" typeURI="http://schemas.dmtf.org/cloud/audit/1.0/event" xsi:schemaLocation="http://schemas.dmtf.org/cloud/audit/1.0/event user-access-cadf.xsd">
<cadf:initiator id="" name="" typeURI="network/node">
<cadf:host address="10.1.68.228" agent="Apache-HttpClient/4.3 (java 1.5)" />
</cadf:initiator>
<cadf:target id="10.23.83.80" name="cloudFeeds" typeURI="service">
<cadf:host address="10.23.83.80" />
</cadf:target>
<cadf:attachments>
<cadf:attachment contentType="ua:auditData" name="auditData">
<cadf:content>
 <ua:auditData version="1">
<ua:region>ORD</ua:region>
<ua:dataCenter>ORD1</ua:dataCenter>
<ua:methodLabel />
<ua:requestURL>http://10.23.83.80:9090/functest1/events/invalidNastId</ua:requestURL>
<ua:queryString />
<ua:tenantId />
<ua:responseMessage>UNAUTHORIZED</ua:responseMessage>
<ua:userName />
<ua:roles />
 </ua:auditData>
</cadf:content>
</cadf:attachment>
</cadf:attachments>
<cadf:observer id="cloudFeeds-repose-repose_localhost" name="repose" typeURI="service/security">
<cadf:host address="repose_localhost" />
</cadf:observer>
<cadf:reason reasonCode="401" reasonType="http://www.iana.org/assignments/http-status-codes/http-status-codes.xml" />
 </cadf:event>
```

So do we have to generate events for these cases?  I think we do as repose only lets you filter based on matching a string against a particular field, you can't match anything based on the absence of any roles.  
