### PR TITLE
CF-1037 - Add support for cloudfeeds:service-observer role

### DIFF
--- a/product_schema_def/xsd/productSchema.xsd
+++ b/product_schema_def/xsd/productSchema.xsd
@@ -152,7 +152,7 @@
             <annotation>
                 <documentation>
                     <html:p>
-                        By default, the cloudfeeds:service-admin role is required to post product events.  This
+                        Default value, if not specified, is cloudfeeds:service-admin. This
                         optional attribute can be set to require a different role than cloudfeeds:service-admin
                         in order to post events.
                     </html:p>

--- a/src/test/scala/test-base.scala
+++ b/src/test/scala/test-base.scala
@@ -79,6 +79,7 @@ class BaseUsageSuite extends BaseValidatorSuite with XPathAssertions {
     register("cadf", "http://schemas.dmtf.org/cloud/audit/1.0/event")
 
   val SERVICE_ADMIN = "cloudfeeds:service-admin"
+  val SERVICE_OBSERVER = "cloudfeeds:service-observer"
   val OBSERVER = "cloudfeeds:observer"
   val IDENTITY_USER_ADMIN = "identity:user-admin"
   val REG_ADMIN = "admin"

--- a/src/test/scala/validation-tests.scala
+++ b/src/test/scala/validation-tests.scala
@@ -25,21 +25,36 @@ class ValidatorSuite extends BaseUsageSuite {
     "rid:" -> "Bad Content: The \"rid:[resourceId]\" category is automatically added by Cloud Feeds.  Alternative \"rid:[other]\" categories cannot be submitted.",
     "type:" -> "Bad Content: The \"type:[eventType]\" category is automatically added by Cloud Feeds.  Alternative \"type:[other]\" categories cannot be submitted.",
     "username:" -> "Bad Content: The \"username:[username]\" category is automatically added by Cloud Feeds.  Alternative \"username:[other]\" categories cannot be submitted.")
-  
-  
-  test( "Getting an entry on a Validated feed should always succeed" ) {
+
+
+  test( "Getting an entry on a Validated feed should always succeed by service-admin" ) {
 
     atomValidator.validate( requestRole( "GET", "/usagetest10/events/entries/urn:uuid:2d6c6484-52ca-b414-6739-bc2062cda7a4", SERVICE_ADMIN), response, chain )
   }
 
-  test( "Getting an entry on an Unvalidated feed should always succeed" ) {
+  test( "Getting an entry on a Validated feed should always succeed by service-observer" ) {
+
+    atomValidator.validate( requestRole( "GET", "/usagetest10/events/entries/urn:uuid:2d6c6484-52ca-b414-6739-bc2062cda7a4", SERVICE_OBSERVER), response, chain )
+  }
+
+  test( "Getting an entry on an Unvalidated feed should always succeed by service-admin" ) {
 
     atomValidator.validate( requestRole( "GET", "/demo/events/entries/urn:uuid:2d6c6484-52ca-b414-6739-bc2062cda7a4",  SERVICE_ADMIN ), response, chain )
   }
 
-  test( "Getting an entry on a product feed should always succeed" ) {
+  test( "Getting an entry on an Unvalidated feed should always succeed by service-observer" ) {
+
+    atomValidator.validate( requestRole( "GET", "/demo/events/entries/urn:uuid:2d6c6484-52ca-b414-6739-bc2062cda7a4",  SERVICE_OBSERVER ), response, chain )
+  }
+
+  test( "Getting an entry on a product feed should always succeed by service-admin" ) {
 
     atomValidator.validate( requestRole( "GET", "/bigdata/events/entries/urn:uuid:2d6c6484-52ca-b414-6739-bc2062cda7a4",  SERVICE_ADMIN ), response, chain )
+  }
+
+  test( "Getting an entry on a product feed should always succeed by service-observer" ) {
+
+    atomValidator.validate( requestRole( "GET", "/bigdata/events/entries/urn:uuid:2d6c6484-52ca-b414-6739-bc2062cda7a4",  SERVICE_OBSERVER ), response, chain )
   }
 
   test("A GET on /buildinfo should always succeed") {
@@ -68,6 +83,17 @@ class ValidatorSuite extends BaseUsageSuite {
 
   test("Posting non-atom XML on an unvalidated feed (usagetest7/events) with content-type of application/atom+xml should fail with a 400") {
     assertResultFailed(atomValidator.validate(request("POST", "/usagetest1/events", "application/atom+xml", <some_xml />, SERVICE_ADMIN), response, chain), 400)
+  }
+
+  test("Posting valid entry with non-usage xml by a cloudfeeds:service-observer should fail with 403") {
+    assertResultFailed( atomValidator.validate(request("POST", "/usagetest1/events", "application/atom+xml",
+      <atom:entry xmlns:atom="http://www.w3.org/2005/Atom">
+        <atom:title>Foo Atom Data</atom:title>
+        <atom:content type="application/xml">
+          <foo xmlns="fooBar.com">
+          </foo>
+        </atom:content>
+      </atom:entry>, false, Map("X-ROLES"->List(SERVICE_OBSERVER ) ) ), response, chain), 403 )
   }
 
 

--- a/wadl/feed.wadl
+++ b/wadl/feed.wadl
@@ -18,11 +18,11 @@
     </resource_type>
 
     <resource_type id="AtomFeed">
-        <method href="#getFeed" rax:roles="cloudfeeds:service-admin"/>
+        <method href="#getFeed" rax:roles="cloudfeeds:service-admin cloudfeeds:service-observer"/>
     </resource_type>
 
     <resource_type id="AtomFeedAllowJson">
-        <method href="#getFeedAllowJson" rax:roles="cloudfeeds:service-admin"/>
+        <method href="#getFeedAllowJson" rax:roles="cloudfeeds:service-admin cloudfeeds:service-observer"/>
     </resource_type>
 
     <resource_type id="Unvalidated">
@@ -33,7 +33,7 @@
             </para>
         </wadl:doc>
         <method href="#addPlainUnvalidatedEntry" rax:roles="cloudfeeds:service-admin"/>
-        <resource path="entries/{id}" rax:roles="cloudfeeds:service-admin">
+        <resource path="entries/{id}" rax:roles="cloudfeeds:service-admin  cloudfeeds:service-observer">
             <param name="id" type="xs:anyURI" style="template"> <doc>Specifies the entry's UUID, for example: urn:uuid:676f3860-447c-40a3-8f61-9791819cc82f</doc></param>
             <method href="#getEntry"/>
         </resource>
@@ -47,7 +47,7 @@
             </para>
         </wadl:doc>
         <method href="#addJsonContentOnly" rax:roles="cloudfeeds:service-admin"/>
-        <resource path="entries/{id}" rax:roles="cloudfeeds:service-admin">
+        <resource path="entries/{id}" rax:roles="cloudfeeds:service-admin cloudfeeds:service-observer">
             <param name="id" type="xs:anyURI" style="template"> <doc>Specifies the entry's UUID, for example: urn:uuid:676f3860-447c-40a3-8f61-9791819cc82f</doc></param>
             <method href="#getEntry"/>
         </resource>
@@ -61,7 +61,7 @@
             </para>
         </wadl:doc>
         <method href="#addPlainEntry" rax:roles="cloudfeeds:service-admin"/>
-        <resource path="entries/{id}" rax:roles="cloudfeeds:service-admin">
+        <resource path="entries/{id}" rax:roles="cloudfeeds:service-admin cloudfeeds:service-observer">
             <param name="id" type="xs:anyURI" style="template"> <doc>Specifies the entry's UUID, for example: urn:uuid:676f3860-447c-40a3-8f61-9791819cc82f</doc></param>
             <method href="#getEntry"/>
         </resource>
@@ -74,7 +74,7 @@
             </para>
         </wadl:doc>
         <method href="#addUsageDeadLetter" rax:roles="cloudfeeds:service-admin"/>
-        <resource path="entries/{id}" rax:roles="cloudfeeds:service-admin">
+        <resource path="entries/{id}" rax:roles="cloudfeeds:service-admin cloudfeeds:service-observer">
             <param name="id" type="xs:anyURI" style="template"> <doc>Specifies the entry's UUID, for example: urn:uuid:676f3860-447c-40a3-8f61-9791819cc82f</doc></param>
             <method href="#getEntry"/>
         </resource>
@@ -88,7 +88,7 @@
     </resource_type>
 
     <resource_type id="FeedsCatalog">
-        <method name="GET" rax:roles="cloudfeeds:service-admin"/>
+        <method name="GET" rax:roles="cloudfeeds:service-admin cloudfeeds:service-observer"/>
     </resource_type>
 
     <!-- METHODS -->


### PR DESCRIPTION
**NOTE:  Don't merge this until https://github.com/rackerlabs/standard-usage-schemas/pull/503 as been merged and ```cloudfeeds:service-observer``` exists in identity & has been assigned to a test role.**

cloudfeeds:service-observer is enabled to be able to read all feeds & entries.  Is not able to POST.