### PR TITLE
CF-1178: fix logic to determine if a node is Rax node

### DIFF
--- a/src/main/xsl/xml2json-feeds.xsl
+++ b/src/main/xsl/xml2json-feeds.xsl
@@ -424,8 +424,8 @@
     </xsl:template>
 
     <!--
-      Return true if the node is defined as a part of the product schema.  This consists when the node matches the
-      included nodes & is not within the execluded namespaces.
+      Return true if the node is defined as a part of the product schema or if it is our core event
+      node. More importantly, it is assumed the node also has @version attribute.
     -->
     <xsl:function name="cldfeeds:isRaxSchemaNode" as="xs:boolean">
         <xsl:param name="theNode" as="node()"/>

--- a/src/main/xsl/xml2json-feeds.xsl
+++ b/src/main/xsl/xml2json-feeds.xsl
@@ -430,14 +430,16 @@
     <xsl:function name="cldfeeds:isRaxSchemaNode" as="xs:boolean">
         <xsl:param name="theNode" as="node()"/>
 
-        <xsl:variable name="ns"        select="namespace-uri($theNode)"/>
-        <xsl:variable name="localName" select="local-name($theNode)"/>
+        <xsl:variable name="ns"          select="namespace-uri($theNode)"/>
+        <xsl:variable name="localName"   select="local-name($theNode)"/>
+        <xsl:variable name="coreEventNs" select="'http://docs.rackspace.com/core/event'"/>
 
         <!-- rax schema nodes must have @version attribute -->
         <xsl:choose>
             <xsl:when test="exists($theNode/@version) and 
-                            (($localName = 'event'   and $ns = 'http://docs.rackspace.com/core/event') or
-                             ($localName = 'product' and $ns != 'http://schemas.dmtf.org/cloud/audit/1.0/event'))">
+                            (($localName = 'event'   and $ns = $coreEventNs) or
+                             ($localName = 'product' and local-name($theNode/..) = 'event' and
+                              namespace-uri($theNode/..) = $coreEventNs))">
                 <xsl:value-of select="true()"/>
             </xsl:when>
             <xsl:otherwise>

--- a/src/main/xsl/xml2json-feeds.xsl
+++ b/src/main/xsl/xml2json-feeds.xsl
@@ -202,7 +202,7 @@
             <xsl:with-param name="ns"><xsl:value-of select="namespace-uri(.)"/></xsl:with-param>
         </xsl:call-template>    
         <xsl:choose>
-            <xsl:when test="cldfeeds:isRaxSchemaNode(local-name(), namespace-uri())">
+            <xsl:when test="cldfeeds:isRaxSchemaNode(.)">
                 <xsl:variable name="namespace" select="string(namespace-uri())" as="xs:string"/>
                 <xsl:variable name="version"   select="@version"                as="xs:string"/>
 
@@ -415,7 +415,7 @@
         <xsl:variable name="includeNodes" select="tokenize('feed entry event product error eventError', ' ')"/>
         <!-- except for these namespaces, e.g., event -->
         <xsl:variable name="excludeNS" 
-		      select="tokenize('http://schemas.dmtf.org/cloud/audit/1.0/event', ' ')"/>
+              select="tokenize('http://schemas.dmtf.org/cloud/audit/1.0/event', ' ')"/>
 
         <xsl:if test="exists(index-of($includeNodes, $localName)) 
             and not(exists(index-of($excludeNS, $ns)))">
@@ -424,21 +424,20 @@
     </xsl:template>
 
     <!--
-      Return true if the node is defined as a part of hte product schema.  This consists when the node matches the
+      Return true if the node is defined as a part of the product schema.  This consists when the node matches the
       included nodes & is not within the execluded namespaces.
     -->
     <xsl:function name="cldfeeds:isRaxSchemaNode" as="xs:boolean">
-        <xsl:param name="localName"/>
-        <xsl:param name="ns"/>
+        <xsl:param name="theNode" as="node()"/>
+
+        <xsl:variable name="ns"        select="namespace-uri($theNode)"/>
+        <xsl:variable name="localName" select="local-name($theNode)"/>
 
         <!-- rax schema nodes must have @version attribute -->
-        <xsl:variable name="includeNodes" select="tokenize('event product', ' ')"/>
-        <xsl:variable name="excludeNS"
-                      select="tokenize('http://schemas.dmtf.org/cloud/audit/1.0/event', ' ')"/>
-
         <xsl:choose>
-            <xsl:when test="exists(index-of($includeNodes, $localName))
-			  and not(exists(index-of($excludeNS, $ns)))">
+            <xsl:when test="exists($theNode/@version) and 
+                            (($localName = 'event'   and $ns = 'http://docs.rackspace.com/core/event') or
+                             ($localName = 'product' and $ns != 'http://schemas.dmtf.org/cloud/audit/1.0/event'))">
                 <xsl:value-of select="true()"/>
             </xsl:when>
             <xsl:otherwise>

--- a/src/test/resources/event-node-random-ns.xml
+++ b/src/test/resources/event-node-random-ns.xml
@@ -1,0 +1,17 @@
+<atom:entry xmlns:atom="http://www.w3.org/2005/Atom"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns="http://www.w3.org/2001/XMLSchema">
+    <atom:title>Random Atom Entry</atom:title>
+    <atom:content type="application/xml">
+        <random:event xmlns:random="http://random.namespace/foobar"
+                    xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+                    id="6fa234aea93f38c26fa234aea93f38c2"
+                    eventType="activity"
+                    typeURI="http://schemas.dmtf.org/cloud/audit/1.0/event"
+                    time="2015-03-12T13:20:00-05:00"
+                    outcome="success">
+            <!--racker -->
+            <random:somenode attr="foo"/>
+        </random:event>
+    </atom:content>
+</atom:entry>

--- a/src/test/scala/Xml2JsonSuite.scala
+++ b/src/test/scala/Xml2JsonSuite.scala
@@ -332,6 +332,17 @@ class Xml2JsonSuite extends BaseUsageSuite {
         .get( "attachments").asInstanceOf[java.util.List[Map[String, AnyRef]]].size() == 2 )
     }
 
+    test( "should transform XML containing event node with random namespace") {
+        val parser = (new JsonParserFactory()).createFastParser()
+
+        val transformResult = transform( new StreamSource( new File( "src/test/resources/event-node-random-ns.xml" ) ) )
+        val transformMap = parser.parseMap( new ByteArrayInputStream( transformResult.getBytes( StandardCharsets.UTF_8 ) ) );
+
+        assert( transformMap.get( "entry" ).asInstanceOf[java.util.Map[String, AnyRef]]
+            .get( "content").asInstanceOf[java.util.Map[String, AnyRef]]
+            .get( "event").asInstanceOf[java.util.Map[String, AnyRef]] != null )
+    }
+
     def transform(inputXML: StreamSource) : String = {
         val trans = templates.newTransformer()
         val writer = new StringWriter()


### PR DESCRIPTION
This is to address the exception when someone accidentally messed up the namespace for CADF events and got this error message:
```
An empty sequence is not allowed as the value of variable $version
```

I have added a unit test to cover this. The unit test failed with the above error message without the fix. After applying the fix, the unit test passed successfully.

I will build an RPM next, install on my iNova, and run regression tests.