### PR TITLE
CF-541 - Ensure Tiamat is kept in synch with standard-usage-schema

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cloudfeeds-nabu"]
+	path = cloudfeeds-nabu
+	url = https://github.com/rackerlabs/cloudfeeds-nabu.git

--- a/pom.xml
+++ b/pom.xml
@@ -438,6 +438,45 @@
     </build>
     <profiles>
         <profile>
+            <id>tiamat-check</id>
+            <properties>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.gmaven</groupId>
+                        <artifactId>gmaven-plugin</artifactId>
+                        <version>${gmaven.version}</version>
+                        <executions>
+                            <execution>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>execute</goal>
+                                </goals>
+                                <configuration>
+                                    <providerSelection>1.8</providerSelection>
+                                    <source>
+
+                                        // verify xslt are the same:
+                                        def files = [ 'nonStringAttrs.xsl', 'rm_private_attrs_for_obs.xsl', 'xml2json-feeds.xsl']
+
+                                        files.each { file ->
+
+                                            def tiamat = new File( "cloudfeeds-nabu/tiamat/src/main/resources/${file}" ).text
+                                            def sus = new File( "target/xslt-artifacts/${file}").text
+
+                                            if (tiamat != sus)
+                                                fail( "The 'target/xslt-artifacts/${file}' has been updated in standard-usage-schemas and needs to be released for groupId: 'com.rackspace.feeds.nabu' artifactId: 'cloudfeeds-nabu' in 'https://github.com/rackerlabs/cloudfeeds-nabu'" )
+                                        }
+                                    </source>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>xerces-build</id>
             <properties>
                 <usage.tests.xsd.impl>Xerces</usage.tests.xsd.impl>


### PR DESCRIPTION
Adding cloudfeeds-nabu submodule to verify that tiamat contains
the latest XSLT generated from SUS.

Adding new tiamat-check profile which:
- diffs the xslt in cloudfeeds-nabu with the corresponding versions in
  standard-usage-schemas.  If different, throw an error.  This is done in
  the compile step as rm_private_attrs_for_obs.xsl is generated during
  the compile step.