### PR TITLE
CF-541 - Ensure Tiamat is kept in synch with standard-usage-schema

### DIFF
--- a/product_schema_def/xsl/productSchema-filterPrivateAttrs.xsl
+++ b/product_schema_def/xsl/productSchema-filterPrivateAttrs.xsl
@@ -52,6 +52,9 @@
             </xslout:template>
             
             <xsl:for-each-group select="$productSchemas//sch:productSchema" group-by="@serviceCode">
+                <xsl:sort select="current-grouping-key()"
+                          data-type="text"
+                          order="ascending"/>
                 <xsl:call-template name="sch:filter_private_attrs">
                     <xsl:with-param name="schemas" select="current-group()"/>
                 </xsl:call-template>
@@ -98,7 +101,10 @@
         <xsl:variable name="namespace" as="xs:anyURI" select="@namespace"/>
         <xsl:variable name="version" as="xs:string" select="@version"/>
         <xsl:variable name="private_attrs">
-            <xsl:for-each select="./sch:attribute[@private = 'true']/@name"> 
+            <xsl:for-each select="./sch:attribute[@private = 'true']/@name">
+                <xsl:sort select="."
+                          data-type="text"
+                          order="ascending"/>
                 <xsl:if test="not(position() = 1)">, </xsl:if>
                 <xsl:text>'</xsl:text>
                 <xsl:value-of select="."/>

--- a/src/main/xsl/productSchema-generate-nonStringAttrs.xsl
+++ b/src/main/xsl/productSchema-generate-nonStringAttrs.xsl
@@ -43,6 +43,9 @@
     
     <xsl:template match="*" mode="loop"> 
         <xsl:for-each select="$productSchemas//sch:productSchema">
+            <xsl:sort select="current()[namespace]"
+                      data-type="text"
+                      order="ascending" />
             <xsl:if test="count(current()//sch:attribute[exists(index-of($nonStringTypes, @type))]) gt 0">
                 <schema key="{@namespace}" version="{@version}">
                     <attributes>


### PR DESCRIPTION
Ordering the generation of the following to ensure that the contents
are ordered.  This prevents spurious diff errors for:
- target/xslt-artifacts/nonStringAttrs.xsl
- target/xslt-artifacts/rm_private_attrs_for_obs.xsl

NOTE:  please accept https://github.com/rackerlabs/cloudfeeds-nabu/pull/48 along with this as it updates the XSLT in tiamat to correspond to these changes.