### PR TITLE
CF-541 - Ensure Tiamat is kept in synch with standard-usage-schema

### DIFF
--- a/src/main/xsl/productSchema-generate-nonStringAttrs.xsl
+++ b/src/main/xsl/productSchema-generate-nonStringAttrs.xsl
@@ -43,13 +43,16 @@
     
     <xsl:template match="*" mode="loop"> 
         <xsl:for-each select="$productSchemas//sch:productSchema">
-            <xsl:sort select="current()[namespace]"
+            <xsl:sort select="@namespace"
                       data-type="text"
                       order="ascending" />
             <xsl:if test="count(current()//sch:attribute[exists(index-of($nonStringTypes, @type))]) gt 0">
                 <schema key="{@namespace}" version="{@version}">
                     <attributes>
                         <xsl:for-each select="current()//sch:attribute[exists(index-of($nonStringTypes, @type))]">
+                            <xsl:sort select="@name"
+                                      data-type="text"
+                                      order="ascending" />
                             <xsl:variable name="myParent" select="parent::node()"/>
     
                             <!-- The following choose-when-otherwise assumes that we only


### PR DESCRIPTION
Fixing the sorting so that nonStringAttrs.xsl is generated in the same order on all machines.