### PR TITLE
CF-541: Ensure Tiamat is kept in synch with standard-usage-schema

### DIFF
--- a/sample_product_schemas/servers.xml
+++ b/sample_product_schemas/servers.xml
@@ -19,10 +19,10 @@
         <attribute name="backstageURL" type="string" use="required" private="true">
             Specifies the backstage URL to access the host.
         </attribute>
-        <attribute name="hostIP" type="string" use="required">
+        <attribute name="hostIP" type="string" use="required" private="true">
             Specifies the IP address of the host.
         </attribute>
-        <attribute name="eventType" type="string" use="required">
+        <attribute name="eventType" type="string" use="required" private="true">
             Specifies the type of monitoring event.
         </attribute>
         <attributeGroup name="slice" minOccurs="0" maxOccurs="unbounded">


### PR DESCRIPTION
This PR basically is to add a couple of private attributes for servers, in specific: huddleID and backstageURL.

I modified sample_product_schemas/servers.xml, I think that's the only place I should do it. If something else is needed, please let me know.

So, we should merge this and then tiamat should fail when running the profile "tiamat-check" since the standard-usage-schema is different to the one in upstream.

After the test, we can revert that merge and forget about that PR.

@shintasmith @usnavi please review