### PR TITLE
CF-1299: add process to convert stripped off normalized wadl to RST files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ target
 wadl/product.wadl
 generated_product_xsds/*
 core_xsd/usage.xsd
+normalized/*
 TODO.org
 _build

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "wadl-tools"]
 	path = wadl-tools
 	url = https://github.com/rackerlabs/wadl-tools.git
-[submodule "docs-migration"]
-	path = docs-migration
-	url = https://github.com/rackerlabs/docs-migration.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,9 @@
 [submodule "cloudfeeds-nabu"]
 	path = cloudfeeds-nabu
 	url = https://github.com/rackerlabs/cloudfeeds-nabu.git
+[submodule "wadl-tools"]
+	path = wadl-tools
+	url = https://github.com/rackerlabs/wadl-tools.git
+[submodule "docs-migration"]
+	path = docs-migration
+	url = https://github.com/rackerlabs/docs-migration.git

--- a/pom.xml
+++ b/pom.xml
@@ -891,6 +891,121 @@
             </build>
         </profile>
         <profile>
+            <id>generate-rst</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>generate-normalized-wadl</id>
+                                <phase>generate-sources</phase>
+                                <configuration>
+                                    <tasks>
+                                        <exec executable="wadl-tools/bin/normalizeWadl.sh">
+                                            <arg value="-f"/>
+                                            <arg value="tree"/>
+                                            <arg value="-w"/>
+                                            <arg value="allfeeds.wadl"/>
+                                        </exec>
+                                    </tasks>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>xml-maven-plugin</artifactId>
+                        <version>1.0</version>
+                        <executions>
+                            <execution>
+                                <id>strip-test-feeds</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>transform</goal>
+                                </goals>
+                                <configuration>
+                                    <transformationSets>
+                                        <transformationSet>
+                                            <dir>${basedir}/normalized</dir>
+                                            <includes>
+                                                <include>allfeeds.wadl</include>
+                                            </includes>
+                                            <outputDir>${project.build.directory}/rst</outputDir>
+                                            <stylesheet>${basedir}/src/main/xsl/striptestfeeds.xsl</stylesheet>
+                                        </transformationSet>
+                                    </transformationSets>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <dependencies>
+                            <dependency>
+                                <groupId>net.sf.saxon</groupId>
+                                <artifactId>Saxon-HE</artifactId>
+                                <version>9.4.0.6</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>rst-install-generate</id>
+                                <phase>process-sources</phase>
+                                <configuration>
+                                    <tasks>
+                                        <exec executable="pip">
+                                            <arg value="install"/>
+                                            <arg value="-e"/>
+                                            <arg value="git+git@github.rackspace.com:Product-DevOps/wadl2rst.git@master#egg=wadl2rst"/>
+                                            <arg value="-I"/>
+                                        </exec>
+                                        <exec executable="wadl2rst"/>
+                                    </tasks>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!--
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-rst-files</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${basedir}/api-docs/dev-guide/api-operations/methods/</outputDirectory>
+                                    <resources>          
+                                        <resource>
+                                            <directory>${basedir}/target/rst/dev-guide/api-operations</directory>
+                                            <filtering>true</filtering>
+                                            <includes>
+                                                <include>get-*tid.rst</include>
+                                                <include>get-*tid-entries-id.rst</include>
+                                            </includes>
+                                        </resource>
+                                    </resources>              
+                                </configuration>         
+                            </execution>
+                        </executions>
+                    </plugin>
+                    -->
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>generate-samples</id>
             <build>
                 <plugins>

--- a/src/main/xsl/striptestfeeds.xsl
+++ b/src/main/xsl/striptestfeeds.xsl
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:w="http://wadl.dev.java.net/2009/02"
+                version="2.0">
+
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="w:resource[@path='functest1']"/>
+    <xsl:template match="w:resource[@path='functest2']"/>
+
+</xsl:stylesheet>

--- a/wadl2rst.config.yaml
+++ b/wadl2rst.config.yaml
@@ -1,0 +1,9 @@
+
+#
+# Example wadl2rst config file
+#
+
+target/rst/allfeeds.wadl:
+    title: Rackspace Cloud Feeds API Guide - API v1.0
+    output_directory: target/rst/dev-guide/api-operations
+


### PR DESCRIPTION
This PR adds a Maven profile to generate RST files. The process is as follows:
* run wadl-tool's normalized wadl, which combines all our wadls and put them in one file
* run striptestfeeds.xsl to remove functest1 and functest2 from the normalized wadl
* pip install wadl2rst (** I don't like this, but this is they told me this is the only way **)
* run wadl2rst to generate RST files from the stripped off normalized wadl

I had meant to add a copy task to copy the generated RST files to the api-docs/dev-guide/api-operations/methods directory but currently I am running into problems with Maven. If I added that copy task, it suppressed the pip install and running of wadl2rst. I will add that later.

I want to submit this PR soon so that @meker12 and @stanzikratel can run this on their own.

**NOTE** this profile requires Python to be installed on where you run this build.

To run this profile:
```
mvn -P generate-rst clean process-sources
```
I'm working on adding this to the README and/or wiki of this repo.