### PR TITLE
CF-1299: fix broken wadl xsl

### DIFF
--- a/product_schema_def/xsl/productSchema-wadl.xsl
+++ b/product_schema_def/xsl/productSchema-wadl.xsl
@@ -115,7 +115,7 @@
                         <wadl:doc>urn:uuid:676f3860-447c-40a3-8f61-9791819cc82f</wadl:doc>
                     </param>
                     <method id="getEntry{$id}Tenant" name="GET">
-                    <wadl:doc xml:lang="EN" title="Get {$eventName}" xmlns="http://docbook.org/ns/docbook">
+                    <doc xml:lang="EN" title="Get {$eventName}" xmlns="http://docbook.org/ns/docbook">
                         <para role="shortdesc">This http request fetches one particular event whose ID is listed in the URI.</para>
                             <xsl:apply-templates select="$currentSchemas" mode="wadlDoc">
                                 <xsl:with-param name="sampleMessages" select="$sampleMessages"/>
@@ -123,7 +123,7 @@
                                 <xsl:with-param name="security">external</xsl:with-param>
                                 <xsl:with-param name="summary" select="$summaryOnly"/>
                             </xsl:apply-templates>
-                    </wadl:doc>
+                    </doc>
                         <xsl:if test="$id != 'CloudMonitoring' and $id != 'CloudServersOpenStack' and $id != 'CloudServers'">
                             <request>
                                 <!-- Restrict representation to application/atom+xml. Means JSON not allowed -->


### PR DESCRIPTION
The snippet of XSLT in this PR causes the following invalid namespace _0 to be generated in the ```wadl/product.wadl``` file:

```
        <method id="getEntryCustomerServiceTenant" name="GET">
            <_0:doc xmlns="http://docbook.org/ns/docbook"
                    xmlns:_0="http://wadl.dev.java.net/2009/02"
                    xml:lang="EN"
                    title="Get CustomerService Event">
               <para role="shortdesc">This http request fetches one particular event whose ID is listed in the URI.</para>
```