### PR TITLE
CF-1299: put back the namespace prefix and prefix-to-namespace mapping

### DIFF
--- a/product_schema_def/xsl/productSchema-wadl.xsl
+++ b/product_schema_def/xsl/productSchema-wadl.xsl
@@ -115,7 +115,9 @@
                         <wadl:doc>urn:uuid:676f3860-447c-40a3-8f61-9791819cc82f</wadl:doc>
                     </param>
                     <method id="getEntry{$id}Tenant" name="GET">
-                    <doc xml:lang="EN" title="Get {$eventName}" xmlns="http://docbook.org/ns/docbook">
+                    <outwadl:doc xml:lang="EN" title="Get {$eventName}" 
+                              xmlns:outwadl="http://wadl.dev.java.net/2009/02" 
+                              xmlns="http://docbook.org/ns/docbook">
                         <para role="shortdesc">This http request fetches one particular event whose ID is listed in the URI.</para>
                             <xsl:apply-templates select="$currentSchemas" mode="wadlDoc">
                                 <xsl:with-param name="sampleMessages" select="$sampleMessages"/>
@@ -123,7 +125,7 @@
                                 <xsl:with-param name="security">external</xsl:with-param>
                                 <xsl:with-param name="summary" select="$summaryOnly"/>
                             </xsl:apply-templates>
-                    </doc>
+                    </outwadl:doc>
                         <xsl:if test="$id != 'CloudMonitoring' and $id != 'CloudServersOpenStack' and $id != 'CloudServers'">
                             <request>
                                 <!-- Restrict representation to application/atom+xml. Means JSON not allowed -->


### PR DESCRIPTION
The generated ```product.wadl``` had incorrect namespace for the ```doc``` element. This is currently how it looks like. The ```doc``` element has the default namespace of docbook.

```
         <method id="getEntryCustomerServiceTenant" name="GET">
            <doc xmlns="http://docbook.org/ns/docbook"
                    xml:lang="EN"
                    title="Get CustomerService Event">
            </doc>
            ...
         </method>
```
This causes the DocBook build to skip a lot of content (the attributes descriptions, the XML and JSON samples), because DocBook was looking for a ```doc``` element with wadl namespace.

This PR fixes the above so that it looks like this:
```
         <method id="getEntryCustomerServiceTenant" name="GET">
            <_0:doc xmlns:outwadl="http://wadl.dev.java.net/2009/02"
                    xmlns="http://docbook.org/ns/docbook"
                    xmlns:_0="http://wadl.dev.java.net/2009/02"
                    xml:lang="EN"
                    title="Get CustomerService Event">
```
Note that the ```doc``` element now has prefix _0 and that prefix is mapped to the wadl namespace. Saxon generated that ```_0``` prefix and I don't know how to get rid of it or clean it up. While it is ugly, the XML is technically correct.

I have built DocBook and output looks ok. It has the attributes table and sample XML and JSON.