### PR TITLE
CF-1299: remove 409 response code from the GET requests

### DIFF
--- a/api-docs/dev-guide/api-operations/methods/get-get-autoscale-event-autoscale-events-tid-entries-id.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-autoscale-event-autoscale-events-tid-entries-id.rst
@@ -90,10 +90,6 @@ This table shows the possible response codes for this operation:
 |                          |                         |have permissions for a   |
 |                          |                         |requested operation.     |
 +--------------------------+-------------------------+-------------------------+
-|409                       |The object already       |Duplicate entry ID sent  |
-|                          |exists.                  |in request. Fix entry    |
-|                          |                         |and repost.              |
-+--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |
 |                          |                         |which prevented it from  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-big-data-event-bigdata-events-tid-entries-id.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-big-data-event-bigdata-events-tid-entries-id.rst
@@ -159,10 +159,6 @@ This table shows the possible response codes for this operation:
 |                          |                         |have permissions for a   |
 |                          |                         |requested operation.     |
 +--------------------------+-------------------------+-------------------------+
-|409                       |The object already       |Duplicate entry ID sent  |
-|                          |exists.                  |in request. Fix entry    |
-|                          |                         |and repost.              |
-+--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |
 |                          |                         |which prevented it from  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-cloud-backup-event-backup-events-tid-entries-id.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-cloud-backup-event-backup-events-tid-entries-id.rst
@@ -186,10 +186,6 @@ This table shows the possible response codes for this operation:
 |                          |                         |have permissions for a   |
 |                          |                         |requested operation.     |
 +--------------------------+-------------------------+-------------------------+
-|409                       |The object already       |Duplicate entry ID sent  |
-|                          |exists.                  |in request. Fix entry    |
-|                          |                         |and repost.              |
-+--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |
 |                          |                         |which prevented it from  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-cloud-block-storage-event-cbs-events-tid-entries-id.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-cloud-block-storage-event-cbs-events-tid-entries-id.rst
@@ -94,10 +94,6 @@ This table shows the possible response codes for this operation:
 |                          |                         |have permissions for a   |
 |                          |                         |requested operation.     |
 +--------------------------+-------------------------+-------------------------+
-|409                       |The object already       |Duplicate entry ID sent  |
-|                          |exists.                  |in request. Fix entry    |
-|                          |                         |and repost.              |
-+--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |
 |                          |                         |which prevented it from  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-cloud-database-event-dbaas-events-tid-entries-id.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-cloud-database-event-dbaas-events-tid-entries-id.rst
@@ -138,10 +138,6 @@ This table shows the possible response codes for this operation:
 |                          |                         |have permissions for a   |
 |                          |                         |requested operation.     |
 +--------------------------+-------------------------+-------------------------+
-|409                       |The object already       |Duplicate entry ID sent  |
-|                          |exists.                  |in request. Fix entry    |
-|                          |                         |and repost.              |
-+--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |
 |                          |                         |which prevented it from  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-cloud-files-event-files-events-tid-entries-id.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-cloud-files-event-files-events-tid-entries-id.rst
@@ -121,10 +121,6 @@ This table shows the possible response codes for this operation:
 |                          |                         |have permissions for a   |
 |                          |                         |requested operation.     |
 +--------------------------+-------------------------+-------------------------+
-|409                       |The object already       |Duplicate entry ID sent  |
-|                          |exists.                  |in request. Fix entry    |
-|                          |                         |and repost.              |
-+--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |
 |                          |                         |which prevented it from  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-cloud-loadbalancers-event-lbaas-events-tid-entries-id.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-cloud-loadbalancers-event-lbaas-events-tid-entries-id.rst
@@ -432,10 +432,6 @@ This table shows the possible response codes for this operation:
 |                          |                         |have permissions for a   |
 |                          |                         |requested operation.     |
 +--------------------------+-------------------------+-------------------------+
-|409                       |The object already       |Duplicate entry ID sent  |
-|                          |exists.                  |in request. Fix entry    |
-|                          |                         |and repost.              |
-+--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |
 |                          |                         |which prevented it from  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-cloud-monitoring-event-monitoring-events-tid-entries-id.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-cloud-monitoring-event-monitoring-events-tid-entries-id.rst
@@ -102,10 +102,6 @@ This table shows the possible response codes for this operation:
 |                          |                         |have permissions for a   |
 |                          |                         |requested operation.     |
 +--------------------------+-------------------------+-------------------------+
-|409                       |The object already       |Duplicate entry ID sent  |
-|                          |exists.                  |in request. Fix entry    |
-|                          |                         |and repost.              |
-+--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |
 |                          |                         |which prevented it from  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-cloud-queueus-event-queues-events-tid-entries-id.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-cloud-queueus-event-queues-events-tid-entries-id.rst
@@ -113,10 +113,6 @@ This table shows the possible response codes for this operation:
 |                          |                         |have permissions for a   |
 |                          |                         |requested operation.     |
 +--------------------------+-------------------------+-------------------------+
-|409                       |The object already       |Duplicate entry ID sent  |
-|                          |exists.                  |in request. Fix entry    |
-|                          |                         |and repost.              |
-+--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |
 |                          |                         |which prevented it from  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-cloud-servers-(openstack)-event-nova-events-tid-entries-id.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-cloud-servers-(openstack)-event-nova-events-tid-entries-id.rst
@@ -185,10 +185,6 @@ This table shows the possible response codes for this operation:
 |                          |                         |have permissions for a   |
 |                          |                         |requested operation.     |
 +--------------------------+-------------------------+-------------------------+
-|409                       |The object already       |Duplicate entry ID sent  |
-|                          |exists.                  |in request. Fix entry    |
-|                          |                         |and repost.              |
-+--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |
 |                          |                         |which prevented it from  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-cloud-servers-event-servers-events-tid-entries-id.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-cloud-servers-event-servers-events-tid-entries-id.rst
@@ -413,10 +413,6 @@ This table shows the possible response codes for this operation:
 |                          |                         |have permissions for a   |
 |                          |                         |requested operation.     |
 +--------------------------+-------------------------+-------------------------+
-|409                       |The object already       |Duplicate entry ID sent  |
-|                          |exists.                  |in request. Fix entry    |
-|                          |                         |and repost.              |
-+--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |
 |                          |                         |which prevented it from  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-cloudidentity-event-identity-events-tid-entries-id.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-cloudidentity-event-identity-events-tid-entries-id.rst
@@ -250,10 +250,6 @@ This table shows the possible response codes for this operation:
 |                          |                         |have permissions for a   |
 |                          |                         |requested operation.     |
 +--------------------------+-------------------------+-------------------------+
-|409                       |The object already       |Duplicate entry ID sent  |
-|                          |exists.                  |in request. Fix entry    |
-|                          |                         |and repost.              |
-+--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |
 |                          |                         |which prevented it from  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-rackspacecdn-event-rackspacecdn-events-tid-entries-id.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-rackspacecdn-event-rackspacecdn-events-tid-entries-id.rst
@@ -234,10 +234,6 @@ This table shows the possible response codes for this operation:
 |                          |                         |have permissions for a   |
 |                          |                         |requested operation.     |
 +--------------------------+-------------------------+-------------------------+
-|409                       |The object already       |Duplicate entry ID sent  |
-|                          |exists.                  |in request. Fix entry    |
-|                          |                         |and repost.              |
-+--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |
 |                          |                         |which prevented it from  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-redhat-enterprise-linux-event-nova-events-tid-entries-id.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-redhat-enterprise-linux-event-nova-events-tid-entries-id.rst
@@ -61,10 +61,6 @@ This table shows the possible response codes for this operation:
 |                          |                         |have permissions for a   |
 |                          |                         |requested operation.     |
 +--------------------------+-------------------------+-------------------------+
-|409                       |The object already       |Duplicate entry ID sent  |
-|                          |exists.                  |in request. Fix entry    |
-|                          |                         |and repost.              |
-+--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |
 |                          |                         |which prevented it from  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-redhat-enterprise-linux-event-servers-events-tid-entries-id.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-redhat-enterprise-linux-event-servers-events-tid-entries-id.rst
@@ -61,10 +61,6 @@ This table shows the possible response codes for this operation:
 |                          |                         |have permissions for a   |
 |                          |                         |requested operation.     |
 +--------------------------+-------------------------+-------------------------+
-|409                       |The object already       |Duplicate entry ID sent  |
-|                          |exists.                  |in request. Fix entry    |
-|                          |                         |and repost.              |
-+--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |
 |                          |                         |which prevented it from  |

--- a/product_schema_def/xsl/productSchema-wadl.xsl
+++ b/product_schema_def/xsl/productSchema-wadl.xsl
@@ -148,11 +148,6 @@
                         <response status="401">
                             <wadl:doc xmlns="http://docbook.org/ns/docbook" title="Unauthorized" xml:lang="EN">Authentication failed, or the user does not have permissions for a requested operation.</wadl:doc>
                         </response>
-                        <response status="409">
-                            <wadl:doc xmlns="http://docbook.org/ns/docbook" title="The object already exists." xml:lang="EN">Duplicate entry ID sent 
-                                in request. Fix entry and repost.
-                            </wadl:doc>
-                        </response>
                         <response status="500">
                             <wadl:doc xmlns="http://docbook.org/ns/docbook" title="Internal Server Error" xml:lang="EN">The server encountered an unexpected condition which prevented it from fulfilling the request.</wadl:doc>
                         </response>
@@ -354,11 +349,6 @@
                         </response>
                         <response status="401">
                             <wadl:doc xmlns="http://docbook.org/ns/docbook" title="Unauthorized" xml:lang="EN">Authentication failed, or the user does not have permissions for a requested operation.</wadl:doc>
-                        </response>
-                        <response status="409">
-                            <wadl:doc xmlns="http://docbook.org/ns/docbook" title="The object already exists." xml:lang="EN">Duplicate entry ID sent 
-                                in request. Fix entry and repost.
-                            </wadl:doc>
                         </response>
                         <response status="500">
                             <wadl:doc xmlns="http://docbook.org/ns/docbook" title="Internal Server Error" xml:lang="EN">The server encountered an unexpected condition which prevented it from fulfilling the request.</wadl:doc>


### PR DESCRIPTION
This PR is to remove the 409 response code from the wadl for the GET resources. 409 means duplicate entry and it only makes sense in the context of POST requests.