### PR TITLE
CF-1317: add Generic CADF samples: xml and json

### DIFF
--- a/message_samples/jsoncontentonlytest/json/billingaudit-cadf.json
+++ b/message_samples/jsoncontentonlytest/json/billingaudit-cadf.json
@@ -1,0 +1,50 @@
+{
+  "entry": {
+    "content": {
+      "@text": {
+          "event": {
+            "typeURI": "http://schemas.dmtf.org/cloud/audit/1.0/event", 
+            "eventTime": "2015-07-10T21:15:57+00:00", 
+            "target": {
+              "typeURI": "service/bss/billing/account", 
+              "id": "020-123456"
+            }, 
+            "observer": {
+              "typeURI": "service", 
+              "id": "billing.Billing-Service-Auditor", 
+              "name": "billing-service-audit"
+            }, 
+            "eventType": "activity", 
+            "initiator": {
+              "typeURI": "network/node", 
+              "id": "billing"
+            }, 
+            "action": "create", 
+            "outcome": "success", 
+            "id": "0fa234aea93f38c26fa234aea93f38g3", 
+            "attachments": [
+              {
+                "content": {
+                  "auditData": {
+                    "ran": "020-123456", 
+                    "stateTransition": "SUCCESSFUL_PAYMENT", 
+                    "amount": "100", 
+                    "version": "1", 
+                    "currency": "USD"
+                  }
+                }, 
+                "contentType": "http://billing.api.rackspacecloud.com/cadf/billing-system-event", 
+                "name": "auditData"
+              }
+            ]
+          }
+      },
+      "type": "application/json"
+    },
+    "@type": "http://www.w3.org/2005/Atom",
+    "title": {
+      "@text": "Billing Audit event",
+      "type": "text"
+    }
+  }
+}

--- a/message_samples/jsoncontentonlytest/xml/billingaudit-cadf.xml
+++ b/message_samples/jsoncontentonlytest/xml/billingaudit-cadf.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ignore <?atom..?>, used for testing -->
+<?atom feed="jsoncontentonlytest/events"?> 
+<atom:entry xmlns="http://docs.rackspace.com/core/event"
+            xmlns:atom="http://www.w3.org/2005/Atom"
+            xmlns:cf-b="http://docs.rackspace.com/usage/cloudfiles/bandwidth">
+    <atom:title type="text">Billing Audit event</atom:title>
+            <atom:content type="application/json">
+        {
+          "event": {
+            "typeURI": "http://schemas.dmtf.org/cloud/audit/1.0/event", 
+            "eventTime": "2015-07-10T21:15:57+00:00", 
+            "target": {
+              "typeURI": "service/bss/billing/account", 
+              "id": "020-123456"
+            }, 
+            "observer": {
+              "typeURI": "service", 
+              "id": "billing.Billing-Service-Auditor", 
+              "name": "billing-service-audit"
+            }, 
+            "eventType": "activity", 
+            "initiator": {
+              "typeURI": "network/node", 
+              "id": "billing"
+            }, 
+            "action": "create", 
+            "outcome": "success", 
+            "id": "0fa234aea93f38c26fa234aea93f38g3", 
+            "attachments": [
+              {
+                "content": {
+                  "auditData": {
+                    "ran": "020-123456", 
+                    "stateTransition": "SUCCESSFUL_PAYMENT", 
+                    "amount": "100", 
+                    "version": "1", 
+                    "currency": "USD"
+                  }
+                }, 
+                "contentType": "http://billing.api.rackspacecloud.com/cadf/billing-system-event", 
+                "name": "auditData"
+              }
+            ]
+          }
+        }
+    </atom:content>
+</atom:entry>

--- a/src/test/scala/sample-messages-tests.scala
+++ b/src/test/scala/sample-messages-tests.scala
@@ -112,6 +112,11 @@ class SampleMessagesSuite extends BaseUsageSuite {
         assert(eventParent != null, "  content should have an eventError")
       }
 
+      // special handling for jsoncontentonlytest samples
+      if ( f.getAbsolutePath().contains("jsoncontentonlytest") ) {
+        eventParent = eventParent.get("@text").get.asInstanceOf[Map[String,Any]]
+      }
+
       val eventObject = eventParent.get("event").get.asInstanceOf[Map[String,Any]]
       assert(eventObject != null, "  content should have an event")
       assert(eventObject.get("id") != null, "  event should have an id")


### PR DESCRIPTION
Add XML and JSON sample files for Generic CADF.

I had to change the test code a little bit to accommodate the Generic CADF, json only feeds. 