### PR TITLE
CF-1299: fix mvn plugin order issue with generate-rst

### DIFF
--- a/api-docs/dev-guide/api-operations/methods/get-get-event-id-cadftestid-events-entries-id.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-event-id-cadftestid-events-entries-id.rst
@@ -35,8 +35,8 @@ This table shows the possible response codes for this operation:
 |404                       |Not Found                |The requested resource   |
 |                          |                         |was not found.           |
 +--------------------------+-------------------------+-------------------------+
-|429                       |Rate Limited             |Retry until the entry is |
-|                          |                         |posted.                  |
+|429                       |Rate Limited             |Too many requests. Wait  |
+|                          |                         |and retry.               |
 +--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-event-id-usagetestid-events-entries-id.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-event-id-usagetestid-events-entries-id.rst
@@ -35,8 +35,8 @@ This table shows the possible response codes for this operation:
 |404                       |Not Found                |The requested resource   |
 |                          |                         |was not found.           |
 +--------------------------+-------------------------+-------------------------+
-|429                       |Rate Limited             |Retry until the entry is |
-|                          |                         |posted.                  |
+|429                       |Rate Limited             |Too many requests. Wait  |
+|                          |                         |and retry.               |
 +--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-feed-autoscale-events-tid.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-feed-autoscale-events-tid.rst
@@ -35,8 +35,8 @@ This table shows the possible response codes for this operation:
 |404                       |Not Found                |The requested resource   |
 |                          |                         |was not found.           |
 +--------------------------+-------------------------+-------------------------+
-|429                       |Rate Limited             |Retry until the entry is |
-|                          |                         |posted.                  |
+|429                       |Rate Limited             |Too many requests. Wait  |
+|                          |                         |and retry.               |
 +--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-feed-backup-events-tid.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-feed-backup-events-tid.rst
@@ -35,8 +35,8 @@ This table shows the possible response codes for this operation:
 |404                       |Not Found                |The requested resource   |
 |                          |                         |was not found.           |
 +--------------------------+-------------------------+-------------------------+
-|429                       |Rate Limited             |Retry until the entry is |
-|                          |                         |posted.                  |
+|429                       |Rate Limited             |Too many requests. Wait  |
+|                          |                         |and retry.               |
 +--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-feed-bigdata-events-tid.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-feed-bigdata-events-tid.rst
@@ -35,8 +35,8 @@ This table shows the possible response codes for this operation:
 |404                       |Not Found                |The requested resource   |
 |                          |                         |was not found.           |
 +--------------------------+-------------------------+-------------------------+
-|429                       |Rate Limited             |Retry until the entry is |
-|                          |                         |posted.                  |
+|429                       |Rate Limited             |Too many requests. Wait  |
+|                          |                         |and retry.               |
 +--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-feed-cadftestid-events.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-feed-cadftestid-events.rst
@@ -35,8 +35,8 @@ This table shows the possible response codes for this operation:
 |404                       |Not Found                |The requested resource   |
 |                          |                         |was not found.           |
 +--------------------------+-------------------------+-------------------------+
-|429                       |Rate Limited             |Retry until the entry is |
-|                          |                         |posted.                  |
+|429                       |Rate Limited             |Too many requests. Wait  |
+|                          |                         |and retry.               |
 +--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-feed-cbs-events-tid.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-feed-cbs-events-tid.rst
@@ -35,8 +35,8 @@ This table shows the possible response codes for this operation:
 |404                       |Not Found                |The requested resource   |
 |                          |                         |was not found.           |
 +--------------------------+-------------------------+-------------------------+
-|429                       |Rate Limited             |Retry until the entry is |
-|                          |                         |posted.                  |
+|429                       |Rate Limited             |Too many requests. Wait  |
+|                          |                         |and retry.               |
 +--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-feed-dbaas-events-tid.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-feed-dbaas-events-tid.rst
@@ -35,8 +35,8 @@ This table shows the possible response codes for this operation:
 |404                       |Not Found                |The requested resource   |
 |                          |                         |was not found.           |
 +--------------------------+-------------------------+-------------------------+
-|429                       |Rate Limited             |Retry until the entry is |
-|                          |                         |posted.                  |
+|429                       |Rate Limited             |Too many requests. Wait  |
+|                          |                         |and retry.               |
 +--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-feed-feeds-access-events-tid.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-feed-feeds-access-events-tid.rst
@@ -35,8 +35,8 @@ This table shows the possible response codes for this operation:
 |404                       |Not Found                |The requested resource   |
 |                          |                         |was not found.           |
 +--------------------------+-------------------------+-------------------------+
-|429                       |Rate Limited             |Retry until the entry is |
-|                          |                         |posted.                  |
+|429                       |Rate Limited             |Too many requests. Wait  |
+|                          |                         |and retry.               |
 +--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-feed-files-events-tid.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-feed-files-events-tid.rst
@@ -35,8 +35,8 @@ This table shows the possible response codes for this operation:
 |404                       |Not Found                |The requested resource   |
 |                          |                         |was not found.           |
 +--------------------------+-------------------------+-------------------------+
-|429                       |Rate Limited             |Retry until the entry is |
-|                          |                         |posted.                  |
+|429                       |Rate Limited             |Too many requests. Wait  |
+|                          |                         |and retry.               |
 +--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-feed-identity-access-events-tid.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-feed-identity-access-events-tid.rst
@@ -35,8 +35,8 @@ This table shows the possible response codes for this operation:
 |404                       |Not Found                |The requested resource   |
 |                          |                         |was not found.           |
 +--------------------------+-------------------------+-------------------------+
-|429                       |Rate Limited             |Retry until the entry is |
-|                          |                         |posted.                  |
+|429                       |Rate Limited             |Too many requests. Wait  |
+|                          |                         |and retry.               |
 +--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-feed-identity-events-tid.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-feed-identity-events-tid.rst
@@ -35,8 +35,8 @@ This table shows the possible response codes for this operation:
 |404                       |Not Found                |The requested resource   |
 |                          |                         |was not found.           |
 +--------------------------+-------------------------+-------------------------+
-|429                       |Rate Limited             |Retry until the entry is |
-|                          |                         |posted.                  |
+|429                       |Rate Limited             |Too many requests. Wait  |
+|                          |                         |and retry.               |
 +--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-feed-lbaas-events-tid.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-feed-lbaas-events-tid.rst
@@ -35,8 +35,8 @@ This table shows the possible response codes for this operation:
 |404                       |Not Found                |The requested resource   |
 |                          |                         |was not found.           |
 +--------------------------+-------------------------+-------------------------+
-|429                       |Rate Limited             |Retry until the entry is |
-|                          |                         |posted.                  |
+|429                       |Rate Limited             |Too many requests. Wait  |
+|                          |                         |and retry.               |
 +--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-feed-monitoring-events-tid.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-feed-monitoring-events-tid.rst
@@ -35,8 +35,8 @@ This table shows the possible response codes for this operation:
 |404                       |Not Found                |The requested resource   |
 |                          |                         |was not found.           |
 +--------------------------+-------------------------+-------------------------+
-|429                       |Rate Limited             |Retry until the entry is |
-|                          |                         |posted.                  |
+|429                       |Rate Limited             |Too many requests. Wait  |
+|                          |                         |and retry.               |
 +--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-feed-nova-access-events-tid.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-feed-nova-access-events-tid.rst
@@ -35,8 +35,8 @@ This table shows the possible response codes for this operation:
 |404                       |Not Found                |The requested resource   |
 |                          |                         |was not found.           |
 +--------------------------+-------------------------+-------------------------+
-|429                       |Rate Limited             |Retry until the entry is |
-|                          |                         |posted.                  |
+|429                       |Rate Limited             |Too many requests. Wait  |
+|                          |                         |and retry.               |
 +--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-feed-nova-events-tid.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-feed-nova-events-tid.rst
@@ -35,8 +35,8 @@ This table shows the possible response codes for this operation:
 |404                       |Not Found                |The requested resource   |
 |                          |                         |was not found.           |
 +--------------------------+-------------------------+-------------------------+
-|429                       |Rate Limited             |Retry until the entry is |
-|                          |                         |posted.                  |
+|429                       |Rate Limited             |Too many requests. Wait  |
+|                          |                         |and retry.               |
 +--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-feed-queues-events-tid.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-feed-queues-events-tid.rst
@@ -35,8 +35,8 @@ This table shows the possible response codes for this operation:
 |404                       |Not Found                |The requested resource   |
 |                          |                         |was not found.           |
 +--------------------------+-------------------------+-------------------------+
-|429                       |Rate Limited             |Retry until the entry is |
-|                          |                         |posted.                  |
+|429                       |Rate Limited             |Too many requests. Wait  |
+|                          |                         |and retry.               |
 +--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-feed-rackspacecdn-events-tid.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-feed-rackspacecdn-events-tid.rst
@@ -35,8 +35,8 @@ This table shows the possible response codes for this operation:
 |404                       |Not Found                |The requested resource   |
 |                          |                         |was not found.           |
 +--------------------------+-------------------------+-------------------------+
-|429                       |Rate Limited             |Retry until the entry is |
-|                          |                         |posted.                  |
+|429                       |Rate Limited             |Too many requests. Wait  |
+|                          |                         |and retry.               |
 +--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-feed-servers-events-tid.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-feed-servers-events-tid.rst
@@ -35,8 +35,8 @@ This table shows the possible response codes for this operation:
 |404                       |Not Found                |The requested resource   |
 |                          |                         |was not found.           |
 +--------------------------+-------------------------+-------------------------+
-|429                       |Rate Limited             |Retry until the entry is |
-|                          |                         |posted.                  |
+|429                       |Rate Limited             |Too many requests. Wait  |
+|                          |                         |and retry.               |
 +--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |

--- a/api-docs/dev-guide/api-operations/methods/get-get-feed-usagetestid-events.rst
+++ b/api-docs/dev-guide/api-operations/methods/get-get-feed-usagetestid-events.rst
@@ -35,8 +35,8 @@ This table shows the possible response codes for this operation:
 |404                       |Not Found                |The requested resource   |
 |                          |                         |was not found.           |
 +--------------------------+-------------------------+-------------------------+
-|429                       |Rate Limited             |Retry until the entry is |
-|                          |                         |posted.                  |
+|429                       |Rate Limited             |Too many requests. Wait  |
+|                          |                         |and retry.               |
 +--------------------------+-------------------------+-------------------------+
 |500                       |Internal Server Error    |The server encountered   |
 |                          |                         |an unexpected condition  |

--- a/pom.xml
+++ b/pom.xml
@@ -451,6 +451,12 @@
                                 <include>product.wadl</include>
                             </includes>
                         </fileset>
+                        <fileset>
+                            <directory>${basedir}/normalized</directory>
+                            <includes>
+                                <include>allfeeds.wadl</include>
+                            </includes>
+                        </fileset>
                     </filesets>
                 </configuration>
             </plugin>
@@ -937,7 +943,7 @@
                             </execution>
                             <execution>
                                 <id>rst-install-generate</id>
-                                <phase>process-sources</phase>
+                                <phase>process-resources</phase>
                                 <configuration>
                                     <tasks>
                                         <property environment="env"/>
@@ -984,7 +990,7 @@
                         <executions>
                             <execution>
                                 <id>strip-test-feeds</id>
-                                <phase>generate-sources</phase>
+                                <phase>process-sources</phase>
                                 <goals>
                                     <goal>transform</goal>
                                 </goals>


### PR DESCRIPTION
While investigating the issue #553 that @meker12 reported, I noticed the execution order of the plugin during the Profile ```generate-rst``` was still messed up. The XSLT striptestfeeds.xsl was executed incorrectly before generate normalized wadl. It worked on my source tree because I had a ```normalized/allfeeds.wadl``` already present. The file was not removed during the ```clean``` phase.

This PR solves the 2 issues:
* add ```normalized/allfeeds.wadl``` to be removed during ```clean``` phase
* move the final run of ```wadl2rst``` to the phase ```process-resources```. So the steps and phases are:
  * generate normalized wadl => generate-sources
  * striptestfeeds.xsl => process-sources
  * wadl2rst => process-resources