### PR TITLE
Update cadf.wadl -== Fix additional fault descriptions

### DIFF
--- a/wadl/cadf.wadl
+++ b/wadl/cadf.wadl
@@ -967,12 +967,13 @@
                            rax:message="getEntryUserAccessEvent: Accept header contains unsupported media types: application/*json"
                            name="ACCEPT"/>
                 </request>
-                <response status="200">
-                    <representation mediaType="application/atom+xml"/>
-                </response>
-                <response status="400 401 409 500 503">
-                    <representation mediaType="application/xml"/>
-                </response>
+               <response status="200">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook" title="OK" xml:lang="EN">The request succeeded.</wadl:doc>
+                <representation mediaType="application/json"/>
+            </response>
+            <!-- On Error -->
+            &commonFaults;
+            &getFaults;
             </method>
         </resource>
     </resource_type>


### PR DESCRIPTION
The cadf.wadl has two sets of 200 response codes and fault codes.  One was updated so that the response and fault codes documentation includes label and description.  This PR updates the second set.