### PR TITLE
CF-1322: fix doc changes that are making Repose unhappy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ target
 .settings
 env
 wadl/product.wadl
+wadl/productDoc.wadl
 generated_product_xsds/*
 core_xsd/usage.xsd
 normalized/*

--- a/pom.xml
+++ b/pom.xml
@@ -690,6 +690,27 @@
                                         </source>
                                     </sources>
                                 </mapping>
+                                <!-- This is a workaround to the recent Documentation related edits 
+                                     to enable WADL to RST generation
+                                -->
+                                <mapping>
+                                    <directory>/etc/repose/usage-schema/src/docbkx/common</directory>
+                                    <filemode>755</filemode>
+                                    <configuration>false</configuration>
+                                    <directoryIncluded>true</directoryIncluded>
+                                </mapping>
+                                <mapping>
+                                    <directory>/etc/repose/usage-schema/src/docbkx/common</directory>
+                                    <username>repose</username>
+                                    <groupname>repose</groupname>
+                                    <filemode>444</filemode>
+                                    <configuration>true</configuration>
+                                    <sources>
+                                        <source>
+                                            <location>src/docbkx/common/common.ent</location>
+                                        </source>
+                                    </sources>
+                                </mapping>
                             </mappings>
                             <!-- Not sure we want to blow away this dir everytime
                             <postremoveScriptlet>
@@ -929,12 +950,32 @@
                                 <phase>generate-sources</phase>
                                 <configuration>
                                     <tasks>
+                                        <!-- rename the productDoc.wadl to product.wadl,
+                                             normalize it, then rename the original back.
+                                             The reason we do this, allfeeds.wadl has
+                                             references everywhere to product.wadl#resource
+                                        -->
+                                        <copy tofile="${basedir}/target/product.wadl.sv">
+                                            <fileset dir="${basedir}/wadl/">
+                                                <include name="product.wadl"/>
+                                            </fileset>
+                                        </copy>
+                                        <copy tofile="${basedir}/wadl/product.wadl">
+                                            <fileset dir="${basedir}/wadl/">
+                                                <include name="productDoc.wadl"/>
+                                            </fileset>
+                                        </copy>
                                         <exec executable="wadl-tools/bin/normalizeWadl.sh">
                                             <arg value="-f" />
                                             <arg value="tree" />
                                             <arg value="-w" />
                                             <arg value="allfeeds.wadl" />
                                         </exec>
+                                        <copy tofile="${basedir}/wadl/product.wadl">
+                                            <fileset dir="${basedir}/target/">
+                                                <include name="product.wadl.sv"/>
+                                            </fileset>
+                                        </copy>
                                     </tasks>
                                 </configuration>
                                 <goals>

--- a/product_schema_def/xsl/productSchema-wadl.xsl
+++ b/product_schema_def/xsl/productSchema-wadl.xsl
@@ -29,6 +29,8 @@
     <xsl:import href="productSchema-summary-util.xsl"/>
     <xsl:import href="../../target/xslt-artifacts/rm_private_attrs_for_obs.xsl"/>
 
+    <xsl:param  name="isForWadl2Rst"/>
+
     <!-- for samples -->
     <xsl:template match="comment()" mode="rm_priv"/>
 
@@ -1152,7 +1154,14 @@
             <xsl:choose>
                 <xsl:when test="$content != ''">
                     <para><emphasis role="bold">XML Sample</emphasis>
-                        <xsdxt:code href="{$sampleXMLFile}"/>
+                        <xsl:choose>
+                            <xsl:when test="$isForWadl2Rst = 'yes'">
+                                <xsdxt:code href="{$sampleXMLFile}"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <programlisting language="xml"><xsl:copy-of select="replace($content,'\n.*atom.*feed.*ignore.*used for testing.*(\n)','$1')"/></programlisting>
+                            </xsl:otherwise>
+                        </xsl:choose>
                     </para>
                 </xsl:when>
                 <xsl:otherwise>
@@ -1163,7 +1172,14 @@
             <xsl:choose>
                 <xsl:when test="$json_content != ''">
                     <para><emphasis role="bold">JSON Sample</emphasis>
-                        <xsdxt:code href="{$sampleJSONFile}"/>
+                        <xsl:choose>
+                            <xsl:when test="$isForWadl2Rst = 'yes'">
+                                <xsdxt:code href="{$sampleJSONFile}"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <programlisting language="json"><xsl:copy-of select="$json_content"/></programlisting>
+                            </xsl:otherwise>
+                        </xsl:choose>
                     </para>
                 </xsl:when>
                 <xsl:otherwise>

--- a/src/xpl/generateWADL.xpl
+++ b/src/xpl/generateWADL.xpl
@@ -6,13 +6,14 @@
     <p:input port="source">
         <p:empty/>
     </p:input>
-    
+
     <p:import href="../../src/xpl/recursive-directory-list.xpl"/>
     
     <l:recursive-directory-list path="../.." name="schemas">
         <p:with-option name="include-filter" select="'.*'"/>
     </l:recursive-directory-list>
     <p:xslt name="generate_WADL">
+        <p:with-param name="isForWadl2Rst" select="'no'"/>
         <p:input port="stylesheet">
             <p:document href="../../product_schema_def/xsl/productSchema-wadl.xsl"/>
         </p:input>
@@ -24,5 +25,27 @@
         </p:input>
     </p:xslt>
     <p:store method="xml" indent="true" encoding="UTF-8"
-        omit-xml-declaration="false" href="../../wadl/product.wadl"/>
+             omit-xml-declaration="false" href="../../wadl/product.wadl">
+        <p:input port="source">
+            <p:pipe step="generate_WADL" port="result"/>
+        </p:input>
+    </p:store>
+    <p:xslt name="generate_DocWADL">
+        <p:with-param name="isForWadl2Rst" select="'yes'"/>
+        <p:input port="stylesheet">
+            <p:document href="../../product_schema_def/xsl/productSchema-wadl.xsl"/>
+        </p:input>
+        <p:input port="source">
+            <p:pipe port="result" step="schemas"/>
+        </p:input>
+        <p:input port="parameters">
+            <p:empty/>
+        </p:input>
+    </p:xslt>
+    <p:store method="xml" indent="true" encoding="UTF-8"
+             omit-xml-declaration="false" href="../../wadl/productDoc.wadl">
+        <p:input port="source">
+            <p:pipe step="generate_DocWADL" port="result"/>
+        </p:input>
+    </p:store>
 </p:declare-step>


### PR DESCRIPTION
The changes are:
* generate 2 wadl files: product.wadl (the one for Repose) and productDoc.wadl (the one for wadl2rst)
* change generate-rst profile to swap out productDoc.wadl and product.wadl
* include common.ent in RPM. This file is used in feed.wadl and cadf.wadl. Repose is unhappy if the file is not there.