### PR TITLE
CF-1329: add aws datacenters and regions

### DIFF
--- a/bad_message_samples/bigdata/BigData-usage-badAwsDc.xml
+++ b/bad_message_samples/bigdata/BigData-usage-badAwsDc.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?atom feed="bigdata/events"?>
+<?expect code="400" message="Bad Content Validating event dataCenter AWS-US-BAD-1"?>
+<atom:entry xmlns:atom="http://www.w3.org/2005/Atom"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns="http://www.w3.org/2001/XMLSchema">
+    <atom:title>BigData</atom:title>
+    <atom:content type="application/xml">
+        <event xmlns="http://docs.rackspace.com/core/event"
+               xmlns:sample="http://docs.rackspace.com/usage/bigdata"
+               id="e53d007a-fc23-11e1-975c-cfa6b29bb814"
+               version="1"
+               resourceId="4a2b42f4-6c63-11e1-815b-7fcbcf67f549"
+               tenantId="1234"
+               startTime="2013-03-15T11:51:11Z"
+               endTime="2013-03-16T00:00:00Z"
+               type="USAGE"
+               dataCenter="AWS-US-BAD-1"
+               region="AWS-US">
+            <sample:product serviceCode="BigData"
+                            version="1"
+                            resourceType="HADOOP_HDP1_1"
+                            flavorId="a"
+                            flavorName="a"
+                            numberServersInCluster="1"
+                            bandwidthIn="0"
+                            bandwidthOut="0"/>
+        </event>
+    </atom:content>
+</atom:entry>

--- a/bad_message_samples/bigdata/BigData-usage-badAwsDcRegionMatch.xml
+++ b/bad_message_samples/bigdata/BigData-usage-badAwsDcRegionMatch.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?atom feed="bigdata/events"?>
+<?expect code="400" message="Bad Content mismatch between region dataCenter"?>
+<atom:entry xmlns:atom="http://www.w3.org/2005/Atom"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns="http://www.w3.org/2001/XMLSchema">
+    <atom:title>BigData</atom:title>
+    <atom:content type="application/xml">
+        <event xmlns="http://docs.rackspace.com/core/event"
+               xmlns:sample="http://docs.rackspace.com/usage/bigdata"
+               id="e53d007a-fc23-11e1-975c-cfa6b29bb814"
+               version="2"
+               resourceId="4a2b42f4-6c63-11e1-815b-7fcbcf67f549"
+               tenantId="1234"
+               startTime="2013-03-15T11:51:11Z"
+               endTime="2013-03-16T00:00:00Z"
+               type="USAGE"
+               dataCenter="AWS-AP-SOUTHEAST-1"
+               region="AWS-US">
+            <sample:product serviceCode="BigData"
+                            version="2"
+                            resourceType="HADOOP_HDP2_1"
+                            flavorId="hadoop1-7"
+                            flavorName="a"
+                            numberServersInCluster="1"
+                            bandwidthIn="0"
+                            bandwidthOut="0"/>
+        </event>
+    </atom:content>
+</atom:entry>

--- a/bad_message_samples/bigdata/BigData-usage-badAwsRegion.xml
+++ b/bad_message_samples/bigdata/BigData-usage-badAwsRegion.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?atom feed="bigdata/events"?>
+<?expect code="400" message="Bad Content Validating event region AWS-BAD"?>
+<atom:entry xmlns:atom="http://www.w3.org/2005/Atom"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns="http://www.w3.org/2001/XMLSchema">
+    <atom:title>BigData</atom:title>
+    <atom:content type="application/xml">
+        <event xmlns="http://docs.rackspace.com/core/event"
+               xmlns:sample="http://docs.rackspace.com/usage/bigdata"
+               id="e53d007a-fc23-11e1-975c-cfa6b29bb814"
+               version="2"
+               resourceId="4a2b42f4-6c63-11e1-815b-7fcbcf67f549"
+               tenantId="1234"
+               startTime="2013-03-15T11:51:11Z"
+               endTime="2013-03-16T00:00:00Z"
+               type="USAGE"
+               dataCenter="AWS-US-WEST-2"
+               region="AWS-BAD">
+            <sample:product serviceCode="BigData"
+                            version="2"
+                            resourceType="HADOOP_HDP2_1"
+                            flavorId="hadoop1-7"
+                            flavorName="a"
+                            numberServersInCluster="1"
+                            bandwidthIn="0"
+                            bandwidthOut="0"/>
+        </event>
+    </atom:content>
+</atom:entry>

--- a/bad_message_samples/misc/RedHat-entry-bad-content.xml
+++ b/bad_message_samples/misc/RedHat-entry-bad-content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?atom feed="servers/events"?>
-<?expect code="400" message="FOO DFW"?>
+<?expect code="400" message="Bad Content Region FOO"?>
 <atom:entry xmlns:atom="http://www.w3.org/2005/Atom">
     <atom:title>AHop Count</atom:title>
     <atom:content type="application/xml">

--- a/core_xsd/core.xsd
+++ b/core_xsd/core.xsd
@@ -498,6 +498,11 @@
                                                   if (@dataCenter = ('LON1','LON3','LON5')) then (@region = 'LON') else
                                                   if (@dataCenter = 'ORD1') then (@region = 'ORD') else
                                                   if (@dataCenter = 'SYD2') then (@region = 'SYD') else
+                                                  if (@dataCenter = ('AWS-US-EAST-1','AWS-US-WEST-1','AWS-US-WEST-2')) then (@region = 'AWS-US') else
+                                                  if (@dataCenter = ('AWS-EU-WEST-1','AWS-EU-CENTRAL-1')) then (@region = 'AWS-EU') else
+                                                  if (@dataCenter = ('AWS-AP-SOUTHEAST-1','AWS-AP-NORTHEAST-1')) then (@region = 'AWS-AP') else
+                                                  if (@dataCenter = 'AWS-AP-SOUTHEAST-2') then (@region = 'AWS-AU') else
+                                                  if (@dataCenter = 'AWS-SA-EAST-1') then (@region = 'AWS-SA') else
                                                   if (@type = ('USAGE','USAGE_SUMMARY','USAGE_SNAPSHOT')) then ((@dataCenter = 'GLOBAL') and (@region = 'GLOBAL'))
                                                   else true()
                                                   "
@@ -693,6 +698,11 @@
             <enumeration value="LON"/>
             <enumeration value="ORD"/>
             <enumeration value="SYD"/>
+            <enumeration value="AWS-US"/>
+            <enumeration value="AWS-EU"/>
+            <enumeration value="AWS-AP"/>
+            <enumeration value="AWS-AU"/>
+            <enumeration value="AWS-SA"/>
         </restriction>
     </simpleType>
 
@@ -726,6 +736,15 @@
             <enumeration value="LON5"/>
             <enumeration value="ORD1"/>
             <enumeration value="SYD2"/>
+            <enumeration value="AWS-US-EAST-1"/>
+            <enumeration value="AWS-US-WEST-1"/>
+            <enumeration value="AWS-US-WEST-2"/>
+            <enumeration value="AWS-EU-WEST-1"/>
+            <enumeration value="AWS-EU-CENTRAL-1"/>
+            <enumeration value="AWS-AP-SOUTHEAST-1"/>
+            <enumeration value="AWS-AP-NORTHEAST-1"/>
+            <enumeration value="AWS-AP-SOUTHEAST-2"/>
+            <enumeration value="AWS-SA-EAST-1"/>
         </restriction>
     </simpleType>
 

--- a/core_xsd/xsd10/_1.0Core.xsd
+++ b/core_xsd/xsd10/_1.0Core.xsd
@@ -403,6 +403,11 @@
             <enumeration value="LON"/>
             <enumeration value="ORD"/>
             <enumeration value="SYD"/>
+            <enumeration value="AWS-US"/>
+            <enumeration value="AWS-EU"/>
+            <enumeration value="AWS-AP"/>
+            <enumeration value="AWS-AU"/>
+            <enumeration value="AWS-SA"/>
         </restriction>
     </simpleType>
 
@@ -435,6 +440,15 @@
             <enumeration value="LON5"/>
             <enumeration value="ORD1"/>
             <enumeration value="SYD2"/>
+            <enumeration value="AWS-US-EAST-1"/>
+            <enumeration value="AWS-US-WEST-1"/>
+            <enumeration value="AWS-US-WEST-2"/>
+            <enumeration value="AWS-EU-WEST-1"/>
+            <enumeration value="AWS-EU-CENTRAL-1"/>
+            <enumeration value="AWS-AP-SOUTHEAST-1"/>
+            <enumeration value="AWS-AP-NORTHEAST-1"/>
+            <enumeration value="AWS-AP-SOUTHEAST-2"/>
+            <enumeration value="AWS-SA-EAST-1"/>
         </restriction>
     </simpleType>
 

--- a/message_samples/bigdata/json/bigdata-bigdata-hadoop_hdp1_1_aws-usage-v1-entry.json
+++ b/message_samples/bigdata/json/bigdata-bigdata-hadoop_hdp1_1_aws-usage-v1-entry.json
@@ -1,0 +1,31 @@
+{
+    "entry": {
+        "@type": "http://www.w3.org/2005/Atom",
+        "title": "BigData",
+        "content": {
+            "event": {
+                "@type": "http://docs.rackspace.com/core/event",
+                "id": "e53d007a-fc23-11e1-975c-cfa6b29bb814",
+                "version": "2",
+                "resourceId": "4a2b42f4-6c63-11e1-815b-7fcbcf67f549",
+                "tenantId": "1234",
+                "startTime": "2013-03-15T11:51:11Z",
+                "endTime": "2013-03-16T00:00:00Z",
+                "type": "USAGE",
+                "dataCenter": "AWS-US-EAST-1",
+                "region": "AWS-US",
+                "product": {
+                    "@type": "http://docs.rackspace.com/usage/bigdata",
+                    "serviceCode": "BigData",
+                    "version": "1",
+                    "resourceType": "HADOOP_HDP1_1",
+                    "flavorId": "a",
+                    "flavorName": "a",
+                    "numberServersInCluster": 1,
+                    "bandwidthIn": 0,
+                    "bandwidthOut": 0
+                }
+            }
+        }
+    }
+}

--- a/message_samples/bigdata/json/bigdata-bigdata-hadoop_hdp1_1_aws-usage-v1-response.json
+++ b/message_samples/bigdata/json/bigdata-bigdata-hadoop_hdp1_1_aws-usage-v1-response.json
@@ -1,0 +1,61 @@
+{
+    "entry": {
+        "@type": "http://www.w3.org/2005/Atom",
+        "category": [
+            {
+                "term": "tid:1234"
+            },
+            {
+                "term": "rgn:AWS-US"
+            },
+            {
+                "term": "dc:AWS-US-EAST-1"
+            },
+            {
+                "term": "rid:4a2b42f4-6c63-11e1-815b-7fcbcf67f549"
+            },
+            {
+                "term": "bigdata.bigdata.hadoop_hdp1_1.usage"
+            },
+            {
+                "term": "type:bigdata.bigdata.hadoop_hdp1_1.usage"
+            }
+        ],
+        "link": [
+            {
+                "href": "https://ord.feeds.api.rackspacecloud.com/bigdata/events/entries/urn:uuid:e53d007a-fc23-11e1-975c-cfa6b29bb814",
+                "rel": "self"
+            }
+        ],
+        "id": "urn:uuid:e53d007a-fc23-11e1-975c-cfa6b29bb814",
+        "title": "BigData",
+        "content": {
+            "event": {
+                "@type": "http://docs.rackspace.com/core/event",
+                "id": "e53d007a-fc23-11e1-975c-cfa6b29bb814",
+                "version": "2",
+                "resourceId": "4a2b42f4-6c63-11e1-815b-7fcbcf67f549",
+                "tenantId": "1234",
+                "startTime": "2013-03-15T11:51:11Z",
+                "endTime": "2013-03-16T00:00:00Z",
+                "type": "USAGE",
+                "dataCenter": "AWS-US-EAST-1",
+                "region": "AWS-US",
+                "product": {
+                    "@type": "http://docs.rackspace.com/usage/bigdata",
+                    "aggregatedClusterDuration": 43729,
+                    "serviceCode": "BigData",
+                    "version": "1",
+                    "resourceType": "HADOOP_HDP1_1",
+                    "flavorId": "a",
+                    "flavorName": "a",
+                    "numberServersInCluster": 1,
+                    "bandwidthIn": 0,
+                    "bandwidthOut": 0
+                }
+            }
+        },
+        "updated": "2013-03-01T19:42:35.507Z",
+        "published": "2013-03-01T19:42:35.507"
+    }
+}

--- a/message_samples/bigdata/json/bigdata-bigdata-hadoop_hdp2_1_aws-usage-v2-entry.json
+++ b/message_samples/bigdata/json/bigdata-bigdata-hadoop_hdp2_1_aws-usage-v2-entry.json
@@ -1,0 +1,31 @@
+{
+    "entry": {
+        "@type": "http://www.w3.org/2005/Atom",
+        "title": "BigData",
+        "content": {
+            "event": {
+                "@type": "http://docs.rackspace.com/core/event",
+                "id": "e53d007a-fc23-11e1-975c-cfa6b29bb814",
+                "version": "2",
+                "resourceId": "4a2b42f4-6c63-11e1-815b-7fcbcf67f549",
+                "tenantId": "1234",
+                "startTime": "2013-03-15T11:51:11Z",
+                "endTime": "2013-03-16T00:00:00Z",
+                "type": "USAGE",
+                "dataCenter": "AWS-US-WEST-1",
+                "region": "AWS-US",
+                "product": {
+                    "@type": "http://docs.rackspace.com/usage/bigdata",
+                    "serviceCode": "BigData",
+                    "version": "2",
+                    "resourceType": "HADOOP_HDP2_1",
+                    "flavorId": "hadoop1-7",
+                    "flavorName": "a",
+                    "numberServersInCluster": 1,
+                    "bandwidthIn": 0,
+                    "bandwidthOut": 0
+                }
+            }
+        }
+    }
+}

--- a/message_samples/bigdata/json/bigdata-bigdata-hadoop_hdp2_1_aws-usage-v2-response.json
+++ b/message_samples/bigdata/json/bigdata-bigdata-hadoop_hdp2_1_aws-usage-v2-response.json
@@ -1,0 +1,61 @@
+{
+    "entry": {
+        "@type": "http://www.w3.org/2005/Atom",
+        "category": [
+            {
+                "term": "tid:1234"
+            },
+            {
+                "term": "rgn:AWS-US"
+            },
+            {
+                "term": "dc:AWS-US-WEST-1"
+            },
+            {
+                "term": "rid:4a2b42f4-6c63-11e1-815b-7fcbcf67f549"
+            },
+            {
+                "term": "bigdata.bigdata.hadoop_hdp2_1.usage"
+            },
+            {
+                "term": "type:bigdata.bigdata.hadoop_hdp2_1.usage"
+            }
+        ],
+        "link": [
+            {
+                "href": "https://ord.feeds.api.rackspacecloud.com/bigdata/events/entries/urn:uuid:e53d007a-fc23-11e1-975c-cfa6b29bb814",
+                "rel": "self"
+            }
+        ],
+        "id": "urn:uuid:e53d007a-fc23-11e1-975c-cfa6b29bb814",
+        "title": "BigData",
+        "content": {
+            "event": {
+                "@type": "http://docs.rackspace.com/core/event",
+                "id": "e53d007a-fc23-11e1-975c-cfa6b29bb814",
+                "version": "2",
+                "resourceId": "4a2b42f4-6c63-11e1-815b-7fcbcf67f549",
+                "tenantId": "1234",
+                "startTime": "2013-03-15T11:51:11Z",
+                "endTime": "2013-03-16T00:00:00Z",
+                "type": "USAGE",
+                "dataCenter": "AWS-US-WEST-1",
+                "region": "AWS-US",
+                "product": {
+                    "@type": "http://docs.rackspace.com/usage/bigdata",
+                    "aggregatedClusterDuration": 43729,
+                    "serviceCode": "BigData",
+                    "version": "2",
+                    "resourceType": "HADOOP_HDP2_1",
+                    "flavorId": "hadoop1-7",
+                    "flavorName": "a",
+                    "numberServersInCluster": 1,
+                    "bandwidthIn": 0,
+                    "bandwidthOut": 0
+                }
+            }
+        },
+        "updated": "2013-03-01T19:42:35.507Z",
+        "published": "2013-03-01T19:42:35.507"
+    }
+}

--- a/message_samples/bigdata/xml/bigdata-bigdata-hadoop_hdp1_1_aws-usage-v1-entry.xml
+++ b/message_samples/bigdata/xml/bigdata-bigdata-hadoop_hdp1_1_aws-usage-v1-entry.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?atom feed="bigdata/events"?>
+<!--
+    This example has been generated using
+    'mvn -P generate-samples clean generate-sources -DproductSchema=sample_product_schemas/bigdata.xml -DfeedName=bigdata' call.
+    Some assumptions have been made when generating this and might not be correct.  Manual modification
+    might be required for the unit tests to pass.
+
+    The assumptions:
+
+      - If the productSchema requires a 'resourceId' attribute, its value is set to
+        '4a2b42f4-6c63-11e1-815b-7fcbcf67f549'.
+      - If the productSchema has <xpathAssertion> nodes, the assertions might not be satisfied
+        by the generated content.
+      - No optional nodes or attributes are generated.
+      - Does not process the 'withEventType' and 'withResource' attributes.
+-->
+<atom:entry xmlns:atom="http://www.w3.org/2005/Atom"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns="http://www.w3.org/2001/XMLSchema">
+    <atom:title>BigData</atom:title>
+    <atom:content type="application/xml">
+        <event xmlns="http://docs.rackspace.com/core/event"
+               xmlns:sample="http://docs.rackspace.com/usage/bigdata"
+               id="e53d007a-fc23-11e1-975c-cfa6b29bb814"
+               version="1"
+               resourceId="4a2b42f4-6c63-11e1-815b-7fcbcf67f549"
+               tenantId="1234"
+               startTime="2013-03-15T11:51:11Z"
+               endTime="2013-03-16T00:00:00Z"
+               type="USAGE"
+               dataCenter="AWS-US-EAST-1"
+               region="AWS-US">
+            <sample:product serviceCode="BigData"
+                            version="1"
+                            resourceType="HADOOP_HDP1_1"
+                            flavorId="a"
+                            flavorName="a"
+                            numberServersInCluster="1"
+                            bandwidthIn="0"
+                            bandwidthOut="0"/>
+        </event>
+    </atom:content>
+</atom:entry>

--- a/message_samples/bigdata/xml/bigdata-bigdata-hadoop_hdp1_1_aws-usage-v1-response.xml
+++ b/message_samples/bigdata/xml/bigdata-bigdata-hadoop_hdp1_1_aws-usage-v1-response.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    This example has been generated using
+    'mvn -P generate-samples clean generate-sources -DproductSchema=sample_product_schemas/bigdata.xml -DfeedName=bigdata' call.
+    Some assumptions have been made when generating this and might not be correct.  Manual modification
+    might be required for the unit tests to pass.
+
+    The assumptions:
+
+      - If the productSchema requires a 'resourceId' attribute, its value is set to
+        '4a2b42f4-6c63-11e1-815b-7fcbcf67f549'.
+      - If the productSchema has <xpathAssertion> nodes, the assertions might not be satisfied
+        by the generated content.
+      - No optional nodes or attributes are generated.
+      - Does not process the 'withEventType' and 'withResource' attributes.
+-->
+<atom:entry xmlns:atom="http://www.w3.org/2005/Atom"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns="http://www.w3.org/2001/XMLSchema">
+    <atom:id>urn:uuid:e53d007a-fc23-11e1-975c-cfa6b29bb814</atom:id>
+    <atom:category term="tid:1234"/>
+    <atom:category term="rgn:AWS-US"/>
+    <atom:category term="dc:AWS-US-EAST-1"/>
+    <atom:category term="rid:4a2b42f4-6c63-11e1-815b-7fcbcf67f549"/>
+    <atom:category term="bigdata.bigdata.hadoop_hdp1_1.usage"/>
+    <atom:category term="type:bigdata.bigdata.hadoop_hdp1_1.usage"/>
+    <atom:title>BigData</atom:title>
+    <atom:content type="application/xml">
+        <event xmlns="http://docs.rackspace.com/core/event"
+               xmlns:sample="http://docs.rackspace.com/usage/bigdata"
+               id="e53d007a-fc23-11e1-975c-cfa6b29bb814"
+               version="2"
+               resourceId="4a2b42f4-6c63-11e1-815b-7fcbcf67f549"
+               tenantId="1234"
+               startTime="2013-03-15T11:51:11Z"
+               endTime="2013-03-16T00:00:00Z"
+               type="USAGE"
+               dataCenter="AWS-US-EAST-1"
+               region="AWS-US">
+            <sample:product aggregatedClusterDuration="43729"
+                            serviceCode="BigData"
+                            version="1"
+                            resourceType="HADOOP_HDP1_1"
+                            flavorId="a"
+                            flavorName="a"
+                            numberServersInCluster="1"
+                            bandwidthIn="0"
+                            bandwidthOut="0"/>
+        </event>
+    </atom:content>
+    <atom:link href="https://ord.feeds.api.rackspacecloud.com/bigdata/events/entries/urn:uuid:e53d007a-fc23-11e1-975c-cfa6b29bb814"
+               rel="self"/>
+    <atom:updated>2013-03-01T19:42:35.507Z</atom:updated>
+    <atom:published>2013-03-01T19:42:35.507</atom:published>
+</atom:entry>

--- a/message_samples/bigdata/xml/bigdata-bigdata-hadoop_hdp2_1_aws-usage-v2-entry.xml
+++ b/message_samples/bigdata/xml/bigdata-bigdata-hadoop_hdp2_1_aws-usage-v2-entry.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?atom feed="bigdata/events"?>
+<!--
+    This example has been generated using
+    'mvn -P generate-samples clean generate-sources -DproductSchema=sample_product_schemas/bigdata.xml -DfeedName=bigdata' call.
+    Some assumptions have been made when generating this and might not be correct.  Manual modification
+    might be required for the unit tests to pass.
+
+    The assumptions:
+
+      - If the productSchema requires a 'resourceId' attribute, its value is set to
+        '4a2b42f4-6c63-11e1-815b-7fcbcf67f549'.
+      - If the productSchema has <xpathAssertion> nodes, the assertions might not be satisfied
+        by the generated content.
+      - No optional nodes or attributes are generated.
+      - Does not process the 'withEventType' and 'withResource' attributes.
+-->
+<atom:entry xmlns:atom="http://www.w3.org/2005/Atom"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns="http://www.w3.org/2001/XMLSchema">
+    <atom:title>BigData</atom:title>
+    <atom:content type="application/xml">
+        <event xmlns="http://docs.rackspace.com/core/event"
+               xmlns:sample="http://docs.rackspace.com/usage/bigdata"
+               id="e53d007a-fc23-11e1-975c-cfa6b29bb814"
+               version="2"
+               resourceId="4a2b42f4-6c63-11e1-815b-7fcbcf67f549"
+               tenantId="1234"
+               startTime="2013-03-15T11:51:11Z"
+               endTime="2013-03-16T00:00:00Z"
+               type="USAGE"
+               dataCenter="AWS-US-WEST-1"
+               region="AWS-US">
+            <sample:product serviceCode="BigData"
+                            version="2"
+                            resourceType="HADOOP_HDP2_1"
+                            flavorId="hadoop1-7"
+                            flavorName="a"
+                            numberServersInCluster="1"
+                            bandwidthIn="0"
+                            bandwidthOut="0"/>
+        </event>
+    </atom:content>
+</atom:entry>

--- a/message_samples/bigdata/xml/bigdata-bigdata-hadoop_hdp2_1_aws-usage-v2-response.xml
+++ b/message_samples/bigdata/xml/bigdata-bigdata-hadoop_hdp2_1_aws-usage-v2-response.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    This example has been generated using
+    'mvn -P generate-samples clean generate-sources -DproductSchema=sample_product_schemas/bigdata.xml -DfeedName=bigdata' call.
+    Some assumptions have been made when generating this and might not be correct.  Manual modification
+    might be required for the unit tests to pass.
+
+    The assumptions:
+
+      - If the productSchema requires a 'resourceId' attribute, its value is set to
+        '4a2b42f4-6c63-11e1-815b-7fcbcf67f549'.
+      - If the productSchema has <xpathAssertion> nodes, the assertions might not be satisfied
+        by the generated content.
+      - No optional nodes or attributes are generated.
+      - Does not process the 'withEventType' and 'withResource' attributes.
+-->
+<atom:entry xmlns:atom="http://www.w3.org/2005/Atom"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns="http://www.w3.org/2001/XMLSchema">
+    <atom:id>urn:uuid:e53d007a-fc23-11e1-975c-cfa6b29bb814</atom:id>
+    <atom:category term="tid:1234"/>
+    <atom:category term="rgn:AWS-US"/>
+    <atom:category term="dc:AWS-US-WEST-1"/>
+    <atom:category term="rid:4a2b42f4-6c63-11e1-815b-7fcbcf67f549"/>
+    <atom:category term="bigdata.bigdata.hadoop_hdp2_1.usage"/>
+    <atom:category term="type:bigdata.bigdata.hadoop_hdp2_1.usage"/>
+    <atom:title>BigData</atom:title>
+    <atom:content type="application/xml">
+        <event xmlns="http://docs.rackspace.com/core/event"
+               xmlns:sample="http://docs.rackspace.com/usage/bigdata"
+               id="e53d007a-fc23-11e1-975c-cfa6b29bb814"
+               version="2"
+               resourceId="4a2b42f4-6c63-11e1-815b-7fcbcf67f549"
+               tenantId="1234"
+               startTime="2013-03-15T11:51:11Z"
+               endTime="2013-03-16T00:00:00Z"
+               type="USAGE"
+               dataCenter="AWS-US-WEST-1"
+               region="AWS-US">
+            <sample:product aggregatedClusterDuration="43729"
+                            serviceCode="BigData"
+                            version="2"
+                            resourceType="HADOOP_HDP2_1"
+                            flavorId="hadoop1-7"
+                            flavorName="a"
+                            numberServersInCluster="1"
+                            bandwidthIn="0"
+                            bandwidthOut="0"/>
+        </event>
+    </atom:content>
+    <atom:link href="https://ord.feeds.api.rackspacecloud.com/bigdata/events/entries/urn:uuid:e53d007a-fc23-11e1-975c-cfa6b29bb814"
+               rel="self"/>
+    <atom:updated>2013-03-01T19:42:35.507Z</atom:updated>
+    <atom:published>2013-03-01T19:42:35.507</atom:published>
+</atom:entry>


### PR DESCRIPTION
add the aws datacenter / region to the schema (for Cloud Big Data and other future products).

See:  https://jira.rax.io/browse/CF-1329

```
datacenter | region
AWS-US-EAST-1 | AWS-US
AWS-US-WEST-1 | AWS-US
AWS-US-WEST-2 | AWS-US

AWS-EU-WEST-1 | AWS-EU
AWS-EU-CENTRAL-1 | AWS-EU

AWS-AP-SOUTHEAST-1 | AWS-AP
AWS-AP-NORTHEAST-1 | AWS-AP

AWS-AP-SOUTHEAST-2 | AWS-AU

AWS-SA-EAST-1 | AWS-SA
```