### PR TITLE
Add metadata to _deconst.json for Edit link

### DIFF
--- a/api-docs/dev-guide/_deconst.json
+++ b/api-docs/dev-guide/_deconst.json
@@ -1,3 +1,8 @@
 {
-  "contentIDBase": "https://github.com/rackerlabs/standard-usage-schemas/"
+  "contentIDBase": "https://github.com/rackerlabs/standard-usage-schemas/",
+  "githubUrl": "https://github.com/rackerlabs/standard-usage-schemas/",
+  "githubBranch": "master",
+  "meta": {
+    "preferGithubIssues": false
+  }
 }


### PR DESCRIPTION
Putting this metadata in place is to support the Edit on Github feature to be added to the docs user interface. The feature is not implemented yet. In the meantime, the metadata has no effect.